### PR TITLE
Bump lens upper version bounds

### DIFF
--- a/jsaddle.cabal
+++ b/jsaddle.cabal
@@ -61,7 +61,7 @@ library
         exposed-modules: Language.Javascript.JSaddle.JMacro
         build-depends: jmacro >=0.6.3 && <0.8
 
-    build-depends: template-haskell -any, base <5, lens >=3.8.5 && <4.5,
+    build-depends: template-haskell -any, base <5, lens >=3.8.5 && <4.6,
                    text >=0.11.2.3 && <1.3, transformers >=0.3.0.0 && <0.5
 
     exposed-modules: Language.Javascript.JSaddle


### PR DESCRIPTION
Allow `jsaddle` to use the latest version of `lens` (4.5).
