### PR TITLE
Removed instance overlapping with GHCJS

### DIFF
--- a/src/Language/Javascript/JSaddle/Types.hs
+++ b/src/Language/Javascript/JSaddle/Types.hs
@@ -47,7 +47,6 @@ type JSStringRef   = JSString
 type Index         = Int
 
 instance Show (JSRef ValueOrObject)
-instance Eq (JSRef ValueOrObject)
 #else
 type Index = CUInt
 #endif


### PR DESCRIPTION
In GHCJS 0.1.0, GHC 7.8.4, jsaddle was failing to build with 

```
src/Language/Javascript/JSaddle/Value.hs:116:29:
    Overlapping instances for Eq JSObjectRef
      arising from the first field of ‘ValObject’ (type ‘JSObjectRef’)
    Matching instances:
      instance Eq (JSRef a) -- Defined in ‘ghcjs-prim-0.1.0.0:GHCJS.Prim’
      instance Eq (JSRef Language.Javascript.JSaddle.Types.ValueOrObject)
        -- Defined in ‘Language.Javascript.JSaddle.Types’
    When deriving the instance for (Eq JSValue)
```

Now builds for me under GHCJS. (Webkit builds as before because of cpp.) It could be I'm just doing something horribly wrong, but I can't guess what it would be.