### PR TITLE
Add android app callback mechanism

### DIFF
--- a/jsaddle-clib/cbits/include/jsaddle.h
+++ b/jsaddle-clib/cbits/include/jsaddle.h
@@ -8,4 +8,8 @@ typedef struct native_callbacks {
   char * jsaddleHtmlData;
 } native_callbacks;
 
+typedef struct app_callbacks {
+  void (* firebaseInstanceIdService_sendRegistrationToServer) (char *);
+} app_callbacks;
+
 #endif

--- a/jsaddle-clib/default.nix
+++ b/jsaddle-clib/default.nix
@@ -1,9 +1,9 @@
-{ mkDerivation, aeson, base, bytestring, jsaddle, stdenv }:
+{ mkDerivation, aeson, base, bytestring, data-default, jsaddle, stdenv, text }:
 mkDerivation {
   pname = "jsaddle-clib";
   version = "0.8.2.0";
   src = builtins.filterSource (path: type: !(builtins.elem (baseNameOf path) [ ".git" "dist" ])) ./.;
-  libraryHaskellDepends = [ aeson base bytestring jsaddle ];
+  libraryHaskellDepends = [ aeson base bytestring data-default jsaddle text ];
   description = "Interface for JavaScript that works with GHCJS and GHC";
   license = stdenv.lib.licenses.mit;
 }

--- a/jsaddle-clib/jsaddle-clib.cabal
+++ b/jsaddle-clib/jsaddle-clib.cabal
@@ -24,7 +24,9 @@ library
         aeson >=0.8.0.2 && <1.2,
         base <5,
         bytestring >=0.10.6.0 && <0.11,
-        jsaddle >= 0.8.0.0 && <0.9
+        jsaddle >= 0.8.0.0 && <0.9,
+        data-default,
+        text
     default-language: Haskell2010
     hs-source-dirs: src
     Include-dirs: cbits/include

--- a/jsaddle-clib/src-ghc/Language/Javascript/JSaddle/CLib.hs
+++ b/jsaddle-clib/src-ghc/Language/Javascript/JSaddle/CLib.hs
@@ -2,19 +2,27 @@
 module Language.Javascript.JSaddle.CLib
   ( jsaddleInit
   , NativeCallbacks (..)
+  , AppCallbacks (..)
+  , AppConfig (..)
+  , pokeAppConfig
+  , appConfigToAppCallbacks
   ) where
 
 import Control.Monad (void)
 import Control.Concurrent (forkIO)
 
-import Data.Monoid ((<>))
-import Data.ByteString (useAsCString, packCString)
-import Data.ByteString.Lazy (ByteString, toStrict, fromStrict)
-import Data.ByteString.Char8 (unpack)
 import Data.Aeson (encode, decode)
+import Data.ByteString (useAsCString, packCString)
+import Data.ByteString.Char8 (unpack)
+import Data.ByteString.Lazy (ByteString, toStrict, fromStrict)
+import Data.Default (def, Default)
+import Data.Monoid ((<>))
+import Data.Text (Text)
+import qualified Data.Text as T
 
-import Foreign.C.String (CString, newCString)
+import Foreign.C.String (CString, newCString, peekCString)
 import Foreign.Ptr (FunPtr, Ptr)
+import Foreign.Storable (poke)
 import Foreign.Marshal.Utils (new)
 
 import Language.Javascript.JSaddle (JSM)
@@ -52,6 +60,22 @@ jsaddleInit jsm evaluateJavascriptAsyncPtr = do
     , _nativeCallbacks_jsaddleJsData = jsaddleJsPtr
     , _nativeCallbacks_jsaddleHtmlData = jsaddleHtmlPtr
     }
+
+data AppConfig = AppConfig
+  { _appConfig_firebaseInstanceIdServiceSendRegistrationToServer :: Text -> IO ()
+  }
+
+instance Default AppConfig where
+  def = AppConfig (\_ -> return ())
+
+appConfigToAppCallbacks :: AppConfig -> IO AppCallbacks
+appConfigToAppCallbacks (AppConfig firebaseReg) = do
+  firebaseRegPtr <- wrapMessageCallback $ \token ->
+    firebaseReg =<< (T.pack <$> peekCString token)
+  return $ AppCallbacks firebaseRegPtr
+
+pokeAppConfig :: Ptr AppCallbacks -> AppConfig -> IO ()
+pokeAppConfig ptr cfg = poke ptr =<< appConfigToAppCallbacks cfg
 
 jsaddleJs :: ByteString
 jsaddleJs = ghcjsHelpers <> "\

--- a/jsaddle-clib/src/Language/Javascript/JSaddle/CLib/Internal.hsc
+++ b/jsaddle-clib/src/Language/Javascript/JSaddle/CLib/Internal.hsc
@@ -26,3 +26,15 @@ instance Storable NativeCallbacks where
     <*> #{peek native_callbacks, jsaddleResult} p
     <*> #{peek native_callbacks, jsaddleJsData} p
     <*> #{peek native_callbacks, jsaddleHtmlData} p
+
+data AppCallbacks = AppCallbacks
+  { _appCallbacks_firebaseInstanceIdService_sendRegistrationToServer :: !(FunPtr (CString -> IO ()))
+  }
+
+instance Storable AppCallbacks where
+  sizeOf _ = #{size app_callbacks}
+  alignment _ = #{alignment app_callbacks}
+  poke p nc = do
+    #{poke app_callbacks, firebaseInstanceIdService_sendRegistrationToServer} p $ _appCallbacks_firebaseInstanceIdService_sendRegistrationToServer nc
+  peek p = AppCallbacks
+    <$> #{peek app_callbacks, firebaseInstanceIdService_sendRegistrationToServer} p


### PR DESCRIPTION
Added a way to get custom callbacks into the android application for common functionality. So far I've only added the callback for firebase device registration (necessary for push notifications on android) but the data structure and pattern can be extended for all kinds of other app callbacks.

I'll be adding device state transitions next using the same pattern (app opened, app closed, app went to background, app became active, etc). 