### PR TITLE
add `MonadUnliftIO` instance for `JSM`

### DIFF
--- a/jsaddle/default.nix
+++ b/jsaddle/default.nix
@@ -1,7 +1,8 @@
 { mkDerivation, aeson, attoparsec, base, base64-bytestring
 , bytestring, containers, deepseq, filepath, ghc-prim, http-types
 , lens, primitive, process, random, ref-tf, scientific, stdenv, stm
-, text, time, transformers, unordered-containers, vector
+, text, time, transformers, unordered-containers, unliftio-core
+, vector
 }:
 mkDerivation {
   pname = "jsaddle";
@@ -11,7 +12,7 @@ mkDerivation {
     aeson attoparsec base base64-bytestring bytestring containers
     deepseq filepath ghc-prim http-types lens primitive process random
     ref-tf scientific stm text time transformers unordered-containers
-    vector
+    unliftio-core vector
   ];
   description = "Interface for JavaScript that works with GHCJS and GHC";
   license = stdenv.lib.licenses.mit;

--- a/jsaddle/jsaddle.cabal
+++ b/jsaddle/jsaddle.cabal
@@ -48,7 +48,8 @@ library
             stm >=2.4.4 && <2.5,
             time >=1.5.0.1 && <1.9,
             unordered-containers >=0.2 && <0.3,
-            vector >=0.10 && <0.13
+            vector >=0.10 && <0.13,
+            unliftio-core >=0.1 && < 0.2
         exposed-modules:
             Data.JSString
             Data.JSString.Internal


### PR DESCRIPTION
@hamishmack , this would be extremely useful (for example lets us use `async` in JSM) but I do not now if it's safe or not. Specifically I do not know if the functions in `JSContextRef` play well with concurrency.