### PR TITLE
Use a higher store number to prevent segfaults

### DIFF
--- a/jsaddle-warp/src/Language/Javascript/JSaddle/WebSockets.hs
+++ b/jsaddle-warp/src/Language/Javascript/JSaddle/WebSockets.hs
@@ -61,7 +61,7 @@ import Control.Concurrent.MVar
         readMVar, newMVar, newEmptyMVar, modifyMVar)
 import Network.Wai.Handler.Warp
        (defaultSettings, setTimeout, setPort, runSettings)
-import Foreign.Store (newStore, readStore, lookupStore)
+import Foreign.Store (newStore, readStore, lookupStore, writeStore, Store(..))
 import Language.Javascript.JSaddle (askJSM)
 import Control.Monad.IO.Class (MonadIO(..))
 
@@ -252,13 +252,13 @@ debugWrapper run = do
              start' <- takeMVar mvar
              n <- stop
              start' n >>= restarter mvar
-    lookupStore shutdown_0 >>= \case
+    lookupStore storeId >>= \case
         Nothing -> do
             restartMVar <- newMVar start
             void . forkIO $ restarter restartMVar (return 0)
-            void $ newStore restartMVar
+            void $ writeStore (Store storeId) restartMVar
         Just shutdownStore -> do
             restartMVar :: MVar (Int -> IO (IO Int)) <- readStore shutdownStore
             void $ tryTakeMVar restartMVar
             putMVar restartMVar start
-  where shutdown_0 = 0
+  where storeId = 354


### PR DESCRIPTION
I've just recently started to try to use jsaddle-warp, and was running into segfaults, like so:

```
cabal: repl failed for exe:test-dev from test-0.17.0. The build process
segfaulted (i.e. SIGSEGV).
```

After some digging, it turned out that my app's foreign-store and your jsaddle-warp's store chose the same `Store` number which lead to the above crash.

I didn't test the code in this pull request yet, it's more intended as pseudo-code that may compile, and a way to ask if you are open to fixing this issue this way. Are you? Or would you have a different fix in mind?