### PR TITLE
jsaddle-warp: Render jsaddle page on 404 (for client side routing) (fixes #34)

### DIFF
--- a/jsaddle/src/Language/Javascript/JSaddle/Run/Files.hs
+++ b/jsaddle/src/Language/Javascript/JSaddle/Run/Files.hs
@@ -31,7 +31,7 @@ indexHtml =
     \</head>\n\
     \<body>\n\
     \</body>\n\
-    \<script src=\"jsaddle.js\"></script>\n\
+    \<script src=\"/jsaddle.js\"></script>\n\
     \</html>"
 
 initState :: ByteString


### PR DESCRIPTION
This just throws away the 404 responses to GET requests and replaces them with the jsaddle index page. This allows SPAs to be reloaded with the client side route, resulting in the application being served instead of a 404 page.