### PR TITLE
Allow badge updates while app is in foreground

### DIFF
--- a/jsaddle-wkwebview/cbits-uikit/AppDelegate.m
+++ b/jsaddle-wkwebview/cbits-uikit/AppDelegate.m
@@ -112,7 +112,9 @@ HsStablePtr global_didFailToRegisterForRemoteNotificationsWithError = 0;
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
     // Sent when the application receives remote notifications in the foreground or background
     // TODO Allow a configurable CString -> IO () to be passed into AppDelegateConfig
-    [UIApplication sharedApplication].applicationIconBadgeNumber=[[[userInfo objectForKey:@"aps"] valueForKey:@"badge"] intValue];
+    if ([userInfo valueForKeyPath:@"aps.badge"] != nil) {
+        [UIApplication sharedApplication].applicationIconBadgeNumber=[[[userInfo objectForKey:@"aps"] objectForKey:@"badge"] intValue];
+    }
     completionHandler(UIBackgroundFetchResultNewData);
 }
 

--- a/jsaddle-wkwebview/cbits-uikit/AppDelegate.m
+++ b/jsaddle-wkwebview/cbits-uikit/AppDelegate.m
@@ -109,6 +109,13 @@ HsStablePtr global_didFailToRegisterForRemoteNotificationsWithError = 0;
     callWithCString([deviceTokenString UTF8String], global_didRegisterForRemoteNotificationsWithDeviceToken);
 }
 
+- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
+    // Sent when the application receives remote notifications in the foreground or background
+    // TODO Allow a configurable CString -> IO () to be passed into AppDelegateConfig
+    [UIApplication sharedApplication].applicationIconBadgeNumber=[[[userInfo objectForKey:@"aps"] valueForKey:@"badge"] intValue];
+    completionHandler(UIBackgroundFetchResultNewData);
+}
+
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
     // Sent to the delegate when Apple Push Notification service cannot successfully complete the registration process.
     NSString *errorString = [error localizedDescription];


### PR DESCRIPTION
Ideally this could be another field in `AppDelegateConfig`, allowing users to take the CString and perform some app specific action when notifications are received.

This is a harmless default action which will allow icon badge number to be updated if the remote notification is received *while the app is in the foreground*. Currently, those are dropped on the floor, and hence the badge updates are ignored and the number can be out of sync with the remote.