### PR TITLE
Provide a file:// url as a base url for wkwebview

### DIFF
--- a/jsaddle-webkit2gtk/src/Language/Javascript/JSaddle/WebKitGTK.hs
+++ b/jsaddle-webkit2gtk/src/Language/Javascript/JSaddle/WebKitGTK.hs
@@ -148,7 +148,7 @@ run main = do
     void . onWebViewLoadChanged webView $ \case
         LoadEventFinished -> runInWebView main webView
         _ -> return ()
-    webViewLoadHtml  webView "" . Just $ "file://" <> T.pack pwd <> "/"
+    webViewLoadHtml webView "" . Just $ "file://" <> T.pack pwd <> "/index.html"
     installQuitHandler webView
     Gtk.main
 

--- a/jsaddle-wkwebview/cbits/WKWebView.m
+++ b/jsaddle-wkwebview/cbits/WKWebView.m
@@ -61,9 +61,9 @@ extern void jsaddleSyncResult(HsStablePtr, JSaddleHandler *, const char * _Nonnu
 
     if(!navigationAction.targetFrame && ![url.scheme isEqualToString:@"file"]) {
         if(openApp(url))
-		    decisionHandler(WKNavigationActionPolicyCancel);
-		else
-		    decisionHandler(WKNavigationActionPolicyAllow);
+        decisionHandler(WKNavigationActionPolicyCancel);
+    else
+        decisionHandler(WKNavigationActionPolicyAllow);
     }
     else
         decisionHandler(WKNavigationActionPolicyAllow);
@@ -95,10 +95,11 @@ void completeSync(JSaddleHandler *handler, const char * _Nonnull s) {
     handler.completionHandler = NULL;
 }
 
-void loadHTMLString(WKWebView *webView, const char * _Nonnull html) {
-    NSString *htmlString = [NSString stringWithCString:html encoding:NSUTF8StringEncoding];
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [webView loadHTMLString:htmlString baseURL:NULL];
+void loadHTMLStringWithBaseURL(WKWebView *webView, const char * _Nonnull html, const char * _Nonnull url) {
+  NSString *htmlString = [NSString stringWithCString:html encoding:NSUTF8StringEncoding];
+  NSURL *baseURL = [NSURL fileURLWithPath:[[NSString alloc] initWithCString:url encoding:NSUTF8StringEncoding]];
+  dispatch_async(dispatch_get_main_queue(), ^{
+      [webView loadHTMLString:htmlString baseURL:baseURL];
     });
 }
 
@@ -121,6 +122,3 @@ void loadBundleFile(WKWebView *webView, const char * _Nonnull file, const char *
         }
     }
 }
-
-
-

--- a/jsaddle-wkwebview/cbits/WKWebView.m
+++ b/jsaddle-wkwebview/cbits/WKWebView.m
@@ -61,9 +61,9 @@ extern void jsaddleSyncResult(HsStablePtr, JSaddleHandler *, const char * _Nonnu
 
     if(!navigationAction.targetFrame && ![url.scheme isEqualToString:@"file"]) {
         if(openApp(url))
-        decisionHandler(WKNavigationActionPolicyCancel);
-    else
-        decisionHandler(WKNavigationActionPolicyAllow);
+            decisionHandler(WKNavigationActionPolicyCancel);
+         else
+            decisionHandler(WKNavigationActionPolicyAllow);
     }
     else
         decisionHandler(WKNavigationActionPolicyAllow);

--- a/jsaddle-wkwebview/jsaddle-wkwebview.cabal
+++ b/jsaddle-wkwebview/jsaddle-wkwebview.cabal
@@ -30,7 +30,9 @@ library
         aeson >=0.8.0.2 && <1.3,
         base <5,
         bytestring >=0.10.6.0 && <0.11,
+        directory,
         jsaddle >= 0.9.4.0 && <0.10,
+        text,
         data-default,
         containers
     default-language: Haskell2010


### PR DESCRIPTION
Resolves #59 and should eventually lead to a clean solution for https://github.com/reflex-frp/reflex-platform/issues/209

This should mean that users on Mac will no longer need to generate an empty
index.html to run the app.
