### PR TITLE
Bump http-types

### DIFF
--- a/jsaddle-warp/jsaddle-warp.cabal
+++ b/jsaddle-warp/jsaddle-warp.cabal
@@ -29,7 +29,7 @@ library
             bytestring >=0.10.6.0 && <0.11,
             containers >=0.5.6.2 && <0.6,
             foreign-store >=0.2 && <0.3,
-            http-types >=0.8.6 && <0.12,
+            http-types >=0.8.6 && <0.13,
             jsaddle >=0.9.4.0 && <0.10,
             stm >=2.4.4 && <2.5,
             text >=1.2.1.3 && <1.3,

--- a/jsaddle/jsaddle.cabal
+++ b/jsaddle/jsaddle.cabal
@@ -40,7 +40,7 @@ library
             deepseq >=1.3 && < 1.5,
             filepath >=1.4.0.0 && <1.5,
             ghc-prim,
-            http-types >=0.8.6 && <0.12,
+            http-types >=0.8.6 && <0.13,
             process >=1.2.3.0 && <1.7,
             random >= 1.1 && < 1.2,
             ref-tf >=0.4.0.1 && <0.5,


### PR DESCRIPTION
Allows me to use servant 0.13 and thus [reflex-servant](https://github.com/Compositional/reflex-servant/issues/5#issuecomment-383127293).