### PR TITLE
Fix jsaddle-wkwebview iOS SDK

### DIFF
--- a/jsaddle-wkwebview/default.nix
+++ b/jsaddle-wkwebview/default.nix
@@ -7,8 +7,8 @@ mkDerivation {
   version = "0.9.4.0";
   src = ./.;
   libraryHaskellDepends = [ aeson base bytestring jsaddle data-default ];
-  libraryFrameworkDepends = with buildPackages; if hostPlatform.useiOSCross or false then [
-    (assert osx_sdk != null; osx_sdk)
+  libraryFrameworkDepends = with buildPackages; if hostPlatform.useiOSPrebuilt then [
+    "${darwin.xcode_8_2}/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System"
   ] else [
     darwin.libobjc
     darwin.apple_sdk.libs.xpc

--- a/jsaddle-wkwebview/default.nix
+++ b/jsaddle-wkwebview/default.nix
@@ -7,6 +7,14 @@ mkDerivation {
   version = "0.9.4.0";
   src = ./.;
   libraryHaskellDepends = [ aeson base bytestring jsaddle data-default ];
+
+  # HACK(matthewbauer): Make sure framework is pulled in first so that
+  # CoreFoundation is correct. Eventually we will update
+  # CoreFoundation in Nixpkgs but that has caused some other issues.
+  preBuild = stdenv.lib.optionalString hostPlatform.useiOSPrebuilt ''
+    NIX_CFLAGS_COMPILE="-F${buildPackages.darwin.xcode_8_2}/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks"
+  '';
+
   libraryFrameworkDepends = with buildPackages; if hostPlatform.useiOSPrebuilt then [
     "${darwin.xcode_8_2}/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System"
   ] else [


### PR DESCRIPTION
We need to use xcode_8_2 here from Nixpkgs. The long path is
unfortunate but probably inevitable until someone defines an "iOS sdk"
derivation for Nixpkgs.

/cc @Ericson2314 