### PR TITLE
Fix jsaddle-wkwebview (again)

### DIFF
--- a/jsaddle-warp/jsaddle-warp.cabal
+++ b/jsaddle-warp/jsaddle-warp.cabal
@@ -57,7 +57,7 @@ test-suite test-tool
             bytestring -any,
             containers -any,
             deepseq -any,
-            doctest >=0.10.1 && <0.12,
+            doctest >=0.10.1 && <0.17,
             filepath >=1.4.0.0 && <1.5,
             ghc-prim -any,
             http-types -any,

--- a/jsaddle-wkwebview/default.nix
+++ b/jsaddle-wkwebview/default.nix
@@ -2,26 +2,29 @@
 , buildPackages, hostPlatform
 }:
 
-let
-  platform = if hostPlatform.useiOSPrebuilt
-             then hostPlatform.xcodePlatform
-             else "MacOSX";
-  sdk = "${buildPackages.darwin.xcode}/Contents/Developer/Platforms/${platform}.platform/Developer/SDKs/${platform}.sdk";
-
-in mkDerivation {
+mkDerivation {
   pname = "jsaddle-wkwebview";
   version = "0.9.4.0";
   src = ./.;
   libraryHaskellDepends = [ aeson base bytestring jsaddle data-default ];
 
-  # HACK(matthewbauer): This overrides the builtin frameworks from
-  # Nixpkgs. There should be a more elegant way to do this without
-  # breaking other cflags - but haven’t found it yet.
-  preBuild = ''
-    NIX_CFLAGS_COMPILE="-F${sdk}/System/Library/Frameworks"
+  # HACK(matthewbauer): Can’t figure out why cf-private framework is
+  #                     not getting pulled in correctly. Has something
+  #                     to with how headers are looked up in xcode.
+  preBuild = stdenv.lib.optionalString (!hostPlatform.useiOSPrebuilt) ''
+    mkdir include
+    ln -s ${buildPackages.darwin.cf-private}/Library/Frameworks/CoreFoundation.framework/Headers include/CoreFoundation
+    export NIX_CFLAGS_COMPILE="-I$PWD/include $NIX_CFLAGS_COMPILE"
   '';
 
-  libraryFrameworkDepends = [ "${sdk}/System" ];
+  libraryFrameworkDepends =
+    stdenv.lib.optional (hostPlatform.useiOSPrebuilt)
+      "${buildPackages.darwin.xcode}/Contents/Developer/Platforms/${hostPlatform.xcodePlatform}.platform/Developer/SDKs/${hostPlatform.xcodePlatform}.sdk/System"
+    ++ stdenv.lib.optional (!hostPlatform.useiOSPrebuilt)
+      (with buildPackages.darwin; with apple_sdk.frameworks; [
+        Cocoa
+        WebKit
+      ]);
   description = "Interface for JavaScript that works with GHCJS and GHC";
   license = stdenv.lib.licenses.mit;
 }


### PR DESCRIPTION
Sorry about the PR spam. The previous version broke some things & also required xcode to build on macOS. This fixes that issue by introducing a hack I had in reflex-platform. No idea how else to fit it.