### PR TITLE
allow aeson 1.3.x and exceptions-0.10.x

### DIFF
--- a/jsaddle-wkwebview/jsaddle-wkwebview.cabal
+++ b/jsaddle-wkwebview/jsaddle-wkwebview.cabal
@@ -35,7 +35,7 @@ library
         hs-source-dirs: src-ghcjs
     else
         build-depends:
-            aeson >=0.8.0.2 && <1.3,
+            aeson >=0.8.0.2 && <1.4,
             bytestring >=0.10.6.0 && <0.11,
             directory,
             jsaddle >= 0.9.4.0 && <0.10,

--- a/jsaddle/jsaddle.cabal
+++ b/jsaddle/jsaddle.cabal
@@ -107,11 +107,11 @@ library
         Language.Javascript.JSaddle.Value
         Language.Javascript.JSaddle.Types
     build-depends:
-        aeson >=0.8.0.2 && <1.3,
+        aeson >=0.8.0.2 && <1.4,
         base <5,
         base64-bytestring >=1.0.0.1 && <1.1,
         bytestring >=0.10.6.0 && <0.11,
-        exceptions >=0.8 && <0.9,
+        exceptions >=0.8 && <0.11,
         lens >=3.8.5 && <4.17,
         primitive >=0.6.1.0 && <0.7,
         text >=1.2.1.3 && <1.3,
@@ -123,5 +123,3 @@ library
         cpp-options: -DCHECK_UNCHECKED
     if flag(call-stacks) || flag(check-unchecked)
         cpp-options: -DJSADDLE_HAS_CALL_STACK
-
-


### PR DESCRIPTION
allow aeson 1.3.x and exceptions-0.10.x   (in order to be compatible with stack lts-12.3)