### PR TITLE
Add Language.Javascript.JSaddle.WebSockets.Compat to other-modules

### DIFF
--- a/jsaddle-warp/jsaddle-warp.cabal
+++ b/jsaddle-warp/jsaddle-warp.cabal
@@ -24,6 +24,8 @@ library
     if !impl(ghcjs -any)
         exposed-modules:
             Language.Javascript.JSaddle.WebSockets
+        other-modules:
+            Language.Javascript.JSaddle.WebSockets.Compat
         build-depends:
             aeson >=0.8.0.2 && <1.4,
             bytestring >=0.10.6.0 && <0.11,


### PR DESCRIPTION
This is needed to prevent linker errors (especially with profiling).