### PR TITLE
Bump version to 0.9.6.0 for Nix

### DIFF
--- a/jsaddle-warp/default.nix
+++ b/jsaddle-warp/default.nix
@@ -6,7 +6,7 @@
 }:
 mkDerivation {
   pname = "jsaddle-warp";
-  version = "0.9.4.0";
+  version = "0.9.6.0";
   src = builtins.filterSource (path: type: !(builtins.elem (baseNameOf path) [ ".git" "dist" ])) ./.;
   libraryHaskellDepends = [
     base

--- a/jsaddle-webkit2gtk/default.nix
+++ b/jsaddle-webkit2gtk/default.nix
@@ -4,7 +4,7 @@
 }:
 mkDerivation {
   pname = "jsaddle-webkit2gtk";
-  version = "0.9.4.0";
+  version = "0.9.6.0";
   src = builtins.filterSource (path: type: !(builtins.elem (baseNameOf path) [ ".git" "dist" ])) ./.;
   libraryHaskellDepends = [
     aeson base bytestring directory gi-gio gi-glib gi-gtk

--- a/jsaddle-wkwebview/default.nix
+++ b/jsaddle-wkwebview/default.nix
@@ -4,7 +4,7 @@
 
 mkDerivation {
   pname = "jsaddle-wkwebview";
-  version = "0.9.4.0";
+  version = "0.9.6.0";
   src = ./.;
   libraryHaskellDepends = [ aeson base bytestring jsaddle data-default ];
 

--- a/jsaddle/default.nix
+++ b/jsaddle/default.nix
@@ -6,7 +6,7 @@
 }:
 mkDerivation {
   pname = "jsaddle";
-  version = "0.9.4.0";
+  version = "0.9.6.0";
   src = builtins.filterSource (path: type: !(builtins.elem (baseNameOf path) [ ".git" "dist" ])) ./.;
   libraryHaskellDepends = [
     aeson base base64-bytestring bytestring exceptions lens primitive


### PR DESCRIPTION
The version in `.cabal` files are already bumped, but these in `.nix` files look left in the older one.