### PR TITLE
Make some callbacks work in wkwebview

### DIFF
--- a/jsaddle-wkwebview/cbits-cocoa/AppDelegate.m
+++ b/jsaddle-wkwebview/cbits-cocoa/AppDelegate.m
@@ -2,6 +2,8 @@
 #import <Cocoa/Cocoa.h>
 #import <WebKit/WebKit.h>
 
+extern void callIO(HsStablePtr);
+extern void callWithCString(const char * _Nonnull, HsStablePtr);
 extern void callWithWebView(WKWebView *, HsStablePtr);
 
 @interface AppDelegate : NSObject <NSApplicationDelegate>
@@ -10,6 +12,10 @@ extern void callWithWebView(WKWebView *, HsStablePtr);
 
 - (instancetype)initApp:(HsStablePtr)handler progName:(NSString *)progName;
 @end
+
+HsStablePtr global_willFinishLaunchingWithOptions = 0;
+HsStablePtr global_didFinishLaunchingWithOptions = 0;
+HsStablePtr global_applicationUniversalLink = 0;
 
 @implementation AppDelegate
 
@@ -37,12 +43,26 @@ extern void callWithWebView(WKWebView *, HsStablePtr);
     WKWebView *webView = [[WKWebView alloc] initWithFrame: [_window.contentView frame] configuration:theConfiguration];
     [_window setContentView:webView];
     callWithWebView(webView, _handler);
+    callIO(global_willFinishLaunchingWithOptions);
+    // Listen to URL events
+    NSAppleEventManager *manager = [NSAppleEventManager sharedAppleEventManager];
+    [manager
+      setEventHandler:self
+      andSelector:@selector(applicationUniversalLink:)
+      forEventClass:kInternetEventClass
+      andEventID:kAEGetURL];
+}
+
+- (void)applicationUniversalLink:(NSAppleEventDescriptor *)event {
+  NSString *url = [[event paramDescriptorForKeyword:keyDirectObject] stringValue];
+  callWithCString([url UTF8String], global_applicationUniversalLink);
 }
 
 -(void)applicationDidFinishLaunching:(NSNotification *)notification {
     [_window orderFrontRegardless];
     [_window center];
     [NSApp activateIgnoringOtherApps:YES];
+    callIO(global_didFinishLaunchingWithOptions);
 }
 
 -(BOOL) applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)app {
@@ -51,8 +71,29 @@ extern void callWithWebView(WKWebView *, HsStablePtr);
 
 @end
 
-void runInWKWebView(HsStablePtr handler, const char * _Nonnull progName) {
+void runInWKWebView(HsStablePtr handler,
+                    const char * _Nonnull progName,
+                    HsStablePtr hs_willFinishLaunchingWithOptions,
+                    HsStablePtr hs_didFinishLaunchingWithOptions,
+                    HsStablePtr hs_applicationDidBecomeActive,
+                    HsStablePtr hs_applicationWillResignActive,
+                    HsStablePtr hs_applicationDidEnterBackground,
+                    HsStablePtr hs_applicationWillEnterForeground,
+                    HsStablePtr hs_applicationWillTerminate,
+                    HsStablePtr hs_applicationSignificantTimeChange,
+                    HsStablePtr hs_applicationUniversalLink,
+                    const uint64_t hs_requestAuthorizationWithOptions,
+                    const uint64_t hs_requestAuthorizationOptionBadge,
+                    const uint64_t hs_requestAuthorizationOptionSound,
+                    const uint64_t hs_requestAuthorizationOptionAlert,
+                    const uint64_t hs_requestAuthorizationOptionCarPlay,
+                    const uint64_t hs_registerForRemoteNotifications,
+                    HsStablePtr hs_didRegisterForRemoteNotificationsWithDeviceToken,
+                    HsStablePtr hs_didFailToRegisterForRemoteNotificationsWithError) {
     @autoreleasepool {
+        global_willFinishLaunchingWithOptions = hs_willFinishLaunchingWithOptions;
+        global_didFinishLaunchingWithOptions = hs_didFinishLaunchingWithOptions;
+        global_applicationUniversalLink = hs_applicationUniversalLink;
         NSApplication *application = [NSApplication sharedApplication];
         AppDelegate *appDelegate = [[AppDelegate alloc] initApp:handler progName:[NSString stringWithCString:progName encoding:NSUTF8StringEncoding]];
         [application setDelegate:appDelegate];


### PR DESCRIPTION
None of the callbacks in AppDelegateConfig were implemented in wkwebview. This PR adds some of the callbacks to cbits-cocoa (just the ones I needed immediately):
> hs_willFinishLaunchingWithOptions, didFinishLaunchingWithOptions, applicationUniversalLink