### PR TITLE
call functions safely in `(#)`, `jsf`, etc.

### DIFF
--- a/jsaddle/src/Language/Javascript/JSaddle/Evaluate.hs
+++ b/jsaddle/src/Language/Javascript/JSaddle/Evaluate.hs
@@ -50,7 +50,7 @@ eval :: (ToJSString script)
      -> JSM JSVal
 #ifdef ghcjs_HOST_OS
 eval script = liftIO $ js_eval (toJSString script)
-foreign import javascript unsafe "$r = eval($1);"
+foreign import javascript safe "$r = eval($1);"
     js_eval :: JSString -> IO JSVal
 #else
 eval = evaluateScript . toJSString

--- a/jsaddle/src/Language/Javascript/JSaddle/Object.hs
+++ b/jsaddle/src/Language/Javascript/JSaddle/Object.hs
@@ -557,7 +557,7 @@ objCallAsFunction :: MakeArgs args
 objCallAsFunction f this args = do
     rargs <- makeArgs args >>= liftIO . Array.fromListIO
     liftIO $ js_apply f this rargs
-foreign import javascript unsafe "$r = $1.apply($2, $3)"
+foreign import javascript safe "$r = $1.apply($2, $3)"
     js_apply :: Object -> Object -> MutableJSArray -> IO JSVal
 #else
 objCallAsFunction f this args = do
@@ -577,7 +577,7 @@ objCallAsConstructor :: MakeArgs args
 objCallAsConstructor f args = do
     rargs <- makeArgs args >>= liftIO . Array.fromListIO
     liftIO $ js_new f rargs
-foreign import javascript unsafe "\
+foreign import javascript safe "\
         switch($2.length) {\
             case 0 : $r = new $1(); break;\
             case 1 : $r = new $1($2[0]); break;\


### PR DESCRIPTION
I think this is a much better default since:

* We define the function-calling function once, therefore
  bloat is not a concern;
* The functions accept arbitrary user-provided functions,
  and therefore it's dangerous to make assumptions about
  their safety.