### PR TITLE
jsaddle-webkit2gtk: Update for JavaScriptCore-4.0 api

### DIFF
--- a/jsaddle-webkit2gtk/jsaddle-webkit2gtk.cabal
+++ b/jsaddle-webkit2gtk/jsaddle-webkit2gtk.cabal
@@ -35,7 +35,7 @@ library
         gi-gtk >=3.0.17 && <3.1,
         gi-webkit2 >=4.0.14 && <4.1,
         gi-javascriptcore >=4.0.14 && <4.1,
-        haskell-gi-base >=0.20 && <0.22,
+        haskell-gi-base >=0.20 && <0.23,
         haskell-gi-overloading ==0.0.*,
         jsaddle >=0.9.4.0 && <0.10,
         text >=1.2.1.3 && <1.3,

--- a/jsaddle-webkit2gtk/src/Language/Javascript/JSaddle/WebKitGTK.hs
+++ b/jsaddle-webkit2gtk/src/Language/Javascript/JSaddle/WebKitGTK.hs
@@ -43,18 +43,13 @@ import Data.Monoid ((<>))
 import Data.ByteString.Lazy (toStrict, fromStrict)
 import qualified Data.ByteString.Lazy as LB (ByteString)
 import Data.Aeson (encode, decode)
-import Data.Text (Text)
 import qualified Data.Text as T (pack)
-import Data.Text.Foreign (fromPtr)
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
-
-import Foreign.Ptr (castPtr, nullPtr)
 
 import Data.GI.Base.BasicTypes (GObject)
 import Data.GI.Base.Signals
        (connectSignalFunPtr, SignalConnectMode(..), SignalConnectMode,
         SignalHandlerId)
-import Data.GI.Base.ManagedPtr (withManagedPtr)
 
 import GI.GLib (timeoutAdd, idleAdd, pattern PRIORITY_HIGH, pattern PRIORITY_DEFAULT)
 import qualified GI.Gtk as Gtk (main, init)
@@ -65,7 +60,7 @@ import GI.Gtk
         widgetGetToplevel, widgetShowAll, onWidgetDestroy,
         mainQuit)
 import GI.Gio (noCancellable)
-import GI.JavaScriptCore (Value(..), GlobalContext(..))
+import GI.JavaScriptCore (valueToString)
 import GI.WebKit2
        (scriptDialogPromptSetText, scriptDialogPromptGetDefaultText,
         scriptDialogGetMessage, scriptDialogGetDialogType,
@@ -74,7 +69,7 @@ import GI.WebKit2
         setSettingsEnableJavascript, webViewNewWithUserContentManager,
         userContentManagerNew,
         userContentManagerRegisterScriptMessageHandler,
-        javascriptResultGetValue, javascriptResultGetGlobalContext,
+        javascriptResultGetJsValue,
         webViewGetUserContentManager,
         mk_UserContentManagerScriptMessageReceivedCallback,
         wrap_UserContentManagerScriptMessageReceivedCallback,
@@ -82,13 +77,6 @@ import GI.WebKit2
         UserContentManagerScriptMessageReceivedCallback, webViewLoadHtml,
         onWebViewLoadChanged, setSettingsEnableDeveloperExtras,
         webViewSetSettings, webViewGetSettings, ScriptDialogType(..))
-
-import Graphics.UI.Gtk.WebKit.JavaScriptCore.JSBase
-       (JSValueRef, JSContextRef)
-import Graphics.UI.Gtk.WebKit.JavaScriptCore.JSStringRef
-       (jsstringgetcharactersptr, jsstringgetlength, jsstringrelease)
-import Graphics.UI.Gtk.WebKit.JavaScriptCore.JSValueRef
-       (jsvaluetostringcopy)
 
 import Language.Javascript.JSaddle (JSM, Results, Batch)
 import Language.Javascript.JSaddle.Run (runJavaScript)
@@ -108,21 +96,6 @@ installQuitHandler wv = void $ installHandler keyboardSignal (Catch (quitWebView
 postGUIAsync :: IO () -> IO ()
 postGUIAsync action =
   void . idleAdd PRIORITY_DEFAULT $ action >> return False
-
-withJSContextRef :: GlobalContext -> (JSContextRef -> IO a) -> IO a
-withJSContextRef (GlobalContext ctx) f = withManagedPtr ctx (f . castPtr)
-
-withJSValueRef :: Value -> (JSValueRef -> IO a) -> IO a
-withJSValueRef (Value ptr) f = withManagedPtr ptr (f . castPtr)
-
-valueToText :: JSContextRef -> JSValueRef -> IO Text
-valueToText ctxRef s = do
-    jsstring <- jsvaluetostringcopy ctxRef s nullPtr
-    l <- jsstringgetlength jsstring
-    p <- jsstringgetcharactersptr jsstring
-    result <- fromPtr (castPtr p) (fromIntegral l)
-    jsstringrelease jsstring
-    return result
 
 run :: JSM () -> IO ()
 run main = do
@@ -177,11 +150,8 @@ addJSaddleHandler :: WebView -> (Results -> IO ()) -> (Results -> IO Batch) -> I
 addJSaddleHandler webView processResult syncResults = do
     manager <- webViewGetUserContentManager webView
     _ <- onUserContentManagerScriptMessageReceived manager $ \result -> do
-        ctx <- javascriptResultGetGlobalContext result
-        arg <- javascriptResultGetValue result
-        bs <- withJSContextRef ctx $ \ctxRef ->
-            withJSValueRef arg $ \argRef ->
-                encodeUtf8 <$> valueToText ctxRef argRef
+        arg <- javascriptResultGetJsValue result
+        bs <- encodeUtf8 <$> valueToString arg
         mapM_ processResult (decode (fromStrict bs))
     _ <- onWebViewScriptDialog webView $ \dialog ->
         scriptDialogGetDialogType dialog >>= \case


### PR DESCRIPTION
javascriptcore-4.0 removed functions related to 'GlobalContext', breaking some existing code. Luckily, we don't need the global context anymore anyway.