### PR TITLE
Fix jsaddle-wkwebview builds

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,6 @@
-haskellPackages: {
+{ pkgs ? import <nixpkgs> {}, haskellPackages ? pkgs.haskellPackages }:
+
+{
   jsaddle = haskellPackages.callPackage ./jsaddle {};
   jsaddle-warp = haskellPackages.callPackage ./jsaddle-warp {};
   jsaddle-wkwebview = haskellPackages.callPackage ./jsaddle-wkwebview {};


### PR DESCRIPTION
Newer nixpkgs resulted in errors like:

```
Undefined symbols for architecture x86_64:
  "_OBJC_CLASS_$_NSURL", referenced from:
      objc-class-ref in libHSjsaddle-wkwebview-0.9.6.0-3Qa6qfm5Iv91uqRz8CkhhF.a(WKWebView.o)
ld: symbol(s) not found for architecture x86_64
```

This adds darwin.cf-private which has this symbol, which swift corefoundation lacks.