### PR TITLE
Detect node system better

### DIFF
--- a/jsaddle-warp/src/Language/Javascript/JSaddle/WebSockets.hs
+++ b/jsaddle-warp/src/Language/Javascript/JSaddle/WebSockets.hs
@@ -164,7 +164,7 @@ jsaddleJs = jsaddleJs' Nothing
 -- sed -e 's|\\|\\\\|g' -e 's|^|    \\|' -e 's|$|\\n\\|' -e 's|"|\\"|g' data/jsaddle.js | pbcopy
 jsaddleJs' :: Maybe ByteString -> Bool -> ByteString
 jsaddleJs' jsaddleUri refreshOnLoad = "\
-    \if(typeof global !== \"undefined\") {\n\
+    \if(typeof global !== \"undefined\" && typeof require == \"function\") {\n\
     \    global.window = global;\n\
     \    global.WebSocket = require('ws');\n\
     \}\n\

--- a/jsaddle-warp/src/Language/Javascript/JSaddle/WebSockets.hs
+++ b/jsaddle-warp/src/Language/Javascript/JSaddle/WebSockets.hs
@@ -164,7 +164,7 @@ jsaddleJs = jsaddleJs' Nothing
 -- sed -e 's|\\|\\\\|g' -e 's|^|    \\|' -e 's|$|\\n\\|' -e 's|"|\\"|g' data/jsaddle.js | pbcopy
 jsaddleJs' :: Maybe ByteString -> Bool -> ByteString
 jsaddleJs' jsaddleUri refreshOnLoad = "\
-    \if(typeof global !== \"undefined\" && typeof require == \"function\") {\n\
+    \if(typeof global !== \"undefined\" && typeof require === \"function\") {\n\
     \    global.window = global;\n\
     \    global.WebSocket = require('ws');\n\
     \}\n\


### PR DESCRIPTION
Some things like webpack create the “global” variable so we cannot
rely on just that to detect nodejs systems. To supplement this, we can
also check for the “require” function. This fixes an issue where
require is undefined when using jsaddle-warp.

/cc @hamishmack @Ericson2314 