### PR TITLE
Made the lens dependency optional

### DIFF
--- a/jsaddle/jsaddle.cabal
+++ b/jsaddle/jsaddle.cabal
@@ -27,6 +27,12 @@ flag check-unchecked
   description: Fail unchecked calls when they are called (rather than when the result is evaluated)
   default: False
 
+flag lens
+  description:
+    Use the 'lens' library. You might want to disable this to reduce executable size.
+    With this disabled all 'IndexPreservingGetter's become 'Getter's.
+  default: True
+
 library
 
     if impl(ghcjs -any)
@@ -106,6 +112,8 @@ library
         Language.Javascript.JSaddle.String
         Language.Javascript.JSaddle.Value
         Language.Javascript.JSaddle.Types
+    other-modules:
+        Control.Lens.Reexported
     build-depends:
         aeson >=0.11.3.0 && <1.6,
         base >=4.9 && <5,
@@ -113,10 +121,14 @@ library
         base64-bytestring >=1.0.0.1 && <1.2,
         bytestring >=0.10.6.0 && <0.11,
         exceptions >=0.8 && <0.11,
-        lens >=3.8.5 && <5.1,
         primitive >=0.6.1.0 && <0.8,
         text >=1.2.1.3 && <1.3,
         transformers >=0.4.2.0 && <0.6
+    if flag(lens)
+        build-depends:
+            lens >=3.8.5 && <5.1
+        cpp-options:
+            -DLENS
     default-language: Haskell2010
     hs-source-dirs: src
     ghc-options: -ferror-spans -Wall

--- a/jsaddle/src-ghc/GHCJS/Buffer.hs
+++ b/jsaddle/src-ghc/GHCJS/Buffer.hs
@@ -19,7 +19,7 @@ module GHCJS.Buffer
 
 import GHCJS.Buffer.Types
 
-import Control.Lens.Operators ((^.))
+import Control.Lens.Reexported
 
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS

--- a/jsaddle/src-ghc/JavaScript/Array.hs
+++ b/jsaddle/src-ghc/JavaScript/Array.hs
@@ -47,7 +47,7 @@ import Control.Monad (void)
 import Language.Javascript.JSaddle.Types
        (JSM, JSVal, SomeJSArray(..), JSArray,
         MutableJSArray, GHCJSPure(..))
-import Control.Lens.Operators ((^.))
+import Control.Lens.Reexported
 import Language.Javascript.JSaddle.Object (js2, js0, (<##), js1, js)
 import Language.Javascript.JSaddle.Value (valToNumber)
 import JavaScript.Array.Internal (create, fromList, fromListIO, toList, toListIO, index, read, push)

--- a/jsaddle/src-ghc/JavaScript/TypedArray/ArrayBuffer.hs
+++ b/jsaddle/src-ghc/JavaScript/TypedArray/ArrayBuffer.hs
@@ -6,7 +6,7 @@ module JavaScript.TypedArray.ArrayBuffer
     , byteLengthIO
     ) where
 
-import Control.Lens.Operators ((^.))
+import Control.Lens.Reexported
 
 import GHCJS.Marshal (fromJSValUnchecked)
 

--- a/jsaddle/src-ghc/JavaScript/TypedArray/Internal.hs
+++ b/jsaddle/src-ghc/JavaScript/TypedArray/Internal.hs
@@ -14,7 +14,7 @@ import GHC.Word
 import GHCJS.Internal.Types
 
 import Control.Monad (void)
-import Control.Lens.Operators ((^.))
+import Control.Lens.Reexported
 
 import GHCJS.Marshal (fromJSValUnchecked)
 

--- a/jsaddle/src/Control/Lens/Reexported.hs
+++ b/jsaddle/src/Control/Lens/Reexported.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Control.Lens.Reexported (
+    (^.),
+    to,
+    IndexPreservingGetter,
+) where
+
+#ifdef LENS
+
+
+import Control.Lens
+
+
+#else
+
+
+import Data.Functor.Contravariant
+import Data.Functor.Const
+
+type Getter s a = forall f. (Contravariant f, Functor f) => (a -> f a) -> s -> f s
+type IndexPreservingGetter s a = Getter s a
+
+type Getting r s a = (a -> Const r a) -> s -> Const r s
+
+(^.) :: s -> Getting a s a -> a
+s ^. l = getConst (l Const s)
+{-# INLINE (^.) #-}
+
+to :: (s -> a) -> Getter s a
+to k f = phantom . f . k
+{-# INLINE to #-}
+
+
+#endif

--- a/jsaddle/src/Language/Javascript/JSaddle/Object.hs
+++ b/jsaddle/src/Language/Javascript/JSaddle/Object.hs
@@ -131,7 +131,7 @@ import Language.Javascript.JSaddle.Marshal.String (ToJSString(..))
 import Language.Javascript.JSaddle.Arguments (MakeArgs(..))
 import Control.Monad.IO.Class (MonadIO(..))
 import Language.Javascript.JSaddle.Properties
-import Control.Lens (IndexPreservingGetter, to)
+import Control.Lens.Reexported
 import Data.IORef (newIORef, readIORef)
 import System.IO.Unsafe (unsafePerformIO)
 


### PR DESCRIPTION
When using the library to develop frontends (compiled with GHCJS) some might want to speed up the page loading time by reducing the size of the generated js. 

`lens` had a pretty big dependency footprint which might otherwise not be needed in a frontend application.

The only thing the `lens` library is _really_ needed for is for generating `IndexPreservingGetter`s. IMO a large portion of the uses of the `IndexPreservingGetter`s is just as plain `Getter`s.

---

This PR adds a flag that disables the `lens` dependency, regressing all `IndexPreservingGetter`s to `Getter`s.

This is not a breaking change since the default is to preserve the previous behavior.