### PR TITLE
Fix building with Stackage Nightly 2022-03-03 (ghc-9.0.2) 

### DIFF
--- a/jsaddle-clib/jsaddle-clib.cabal
+++ b/jsaddle-clib/jsaddle-clib.cabal
@@ -21,7 +21,7 @@ library
         Language.Javascript.JSaddle.CLib
         Language.Javascript.JSaddle.CLib.Internal
     build-depends:
-        aeson >=0.8.0.2 && <1.6,
+        aeson >=0.8.0.2 && <2.1,
         base <5,
         base-compat >=0.9.0 && <0.12,
         bytestring >=0.10.6.0 && <0.11,

--- a/jsaddle-warp/jsaddle-warp.cabal
+++ b/jsaddle-warp/jsaddle-warp.cabal
@@ -27,7 +27,7 @@ library
         other-modules:
             Language.Javascript.JSaddle.WebSockets.Compat
         build-depends:
-            aeson >=0.8.0.2 && <1.6,
+            aeson >=0.8.0.2 && <2.1,
             bytestring >=0.10.6.0 && <0.11,
             containers >=0.5.6.2 && <0.7,
             foreign-store >=0.2 && <0.3,

--- a/jsaddle-webkit2gtk/jsaddle-webkit2gtk.cabal
+++ b/jsaddle-webkit2gtk/jsaddle-webkit2gtk.cabal
@@ -26,7 +26,7 @@ library
         base <5
     if !impl(ghcjs -any)
       build-depends:
-        aeson >=0.8.0.2 && <1.6,
+        aeson >=0.8.0.2 && <2.1,
         base <5,
         bytestring >=0.10.6.0 && <0.11,
         directory >=1.0.0.2 && <1.4,

--- a/jsaddle/jsaddle.cabal
+++ b/jsaddle/jsaddle.cabal
@@ -35,7 +35,7 @@ library
             ghcjs-prim -any
     else
         build-depends:
-            attoparsec >=0.11 && <0.14,
+            attoparsec >=0.11 && <0.15,
             containers >=0.5.6.2 && <0.7,
             deepseq >=1.3 && < 1.5,
             filepath >=1.4.0.0 && <1.5,
@@ -107,10 +107,10 @@ library
         Language.Javascript.JSaddle.Value
         Language.Javascript.JSaddle.Types
     build-depends:
-        aeson >=0.11.3.0 && <1.6,
+        aeson >=0.11.3.0 && <2.1,
         base >=4.9 && <5,
         base-compat >=0.9.0 && <0.12,
-        base64-bytestring >=1.0.0.1 && <1.2,
+        base64-bytestring >=1.0.0.1 && <1.3,
         bytestring >=0.10.6.0 && <0.11,
         exceptions >=0.8 && <0.11,
         lens >=3.8.5 && <5.1,

--- a/jsaddle/src/Language/Javascript/JSaddle/Object.hs
+++ b/jsaddle/src/Language/Javascript/JSaddle/Object.hs
@@ -188,7 +188,7 @@ this !! index = do
 js :: (MakeObject s, ToJSString name)
    => name          -- ^ Name of the property to find
    -> IndexPreservingGetter s (JSM JSVal)
-js name = to (!name)
+js name = to (! name)
 
 -- | Makes a setter for a particular property name.
 --


### PR DESCRIPTION
This patch allows building the jsaddle packages with the current stackage nightly.

I wasn't able to build the test suite, since webdriver isn't yet compatible with aeson 2.0, so I haven't been able to verify if the tests still pass.