### PR TITLE
jsaddle-webkit2gtk: gi-gio 2.0.32 support

### DIFF
--- a/jsaddle-webkit2gtk/src/Language/Javascript/JSaddle/WebKitGTK.hs
+++ b/jsaddle-webkit2gtk/src/Language/Javascript/JSaddle/WebKitGTK.hs
@@ -139,7 +139,7 @@ runInWebView f webView = do
 
     addJSaddleHandler webView processResults syncResults
     webViewRunJavascript webView (decodeUtf8 $ toStrict jsaddleJs) noCancellable . Just $
-        \_obj _asyncResult ->
+        \_obj _asyncResult _data ->
             void $ forkIO start
 
 onUserContentManagerScriptMessageReceived :: (IsUserContentManager a, MonadIO m) => a -> UserContentManagerScriptMessageReceivedCallback -> m SignalHandlerId


### PR DESCRIPTION
For reasons unknown to me, the type `AsyncReadyCallback` from `GI.Gio.Callback` changed from
```
Maybe Object -> AsyncResult  -> IO ()
```
in gi-gio 2.0.30
```
Maybe Object -> AsyncResult -> Ptr () -> IO ()
```
in gi-gio 2.0.32, without a mention in the changelog. This came up during the update to webkit 2.40 in nixpkgs.

This patch fixes the build of jsaddle-webkit2gtk and I tested an application built with it.
I hope it’s not our job to somehow free the pointer I am ignoring here, but I don’t think so …

It is worth mentioning that `webViewRunJavascript` has a deprecation warning since webkit 2.40.
I didn’t invest more effort in replacing that call since I am unclear what’s going to happen with jsaddle and the ghc new javascript backend.