### PR TITLE
Remove unnecessary usage of `JavaScriptFFI`

### DIFF
--- a/jsaddle/src-ghc/JavaScript/TypedArray/DataView/Internal.hs
+++ b/jsaddle/src-ghc/JavaScript/TypedArray/DataView/Internal.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE JavaScriptFFI #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE UnliftedFFITypes #-}
 {-# LANGUAGE GHCForeignImportPrim #-}


### PR DESCRIPTION
Non-JS targets don't support this extension since GHC 9.8:

https://gitlab.haskell.org/ghc/ghc/-/commit/0350b1865f392cf9590c82b5194b62e63770aa44