### PR TITLE
Remove dir path from data-files

### DIFF
--- a/jsaddle-warp/jsaddle-warp.cabal
+++ b/jsaddle-warp/jsaddle-warp.cabal
@@ -40,7 +40,6 @@ data-files:
     node-client/node_modules/xmlhttprequest/.npmignore
     node-client/node_modules/xmlhttprequest/LICENSE
     node-client/node_modules/xmlhttprequest/README.md
-    node-client/node_modules/xmlhttprequest/lib
     node-client/node_modules/xmlhttprequest/lib/XMLHttpRequest.js
     node-client/node_modules/xmlhttprequest/package.json
     node-client/package-lock.json


### PR DESCRIPTION
Looks like #156 missed one entry - fixes an error when building in nixpkgs:
```
Documentation created: dist/doc/html/jsaddle-warp/,
dist/doc/html/jsaddle-warp/jsaddle-warp.txt
Running phase: installPhase
Error: Setup: filepath wildcard 'node-client/node_modules/xmlhttprequest/lib'
does not match any files.
```