### PR TITLE
Upstream orphan instances on primitive types

### DIFF
--- a/jsaddle/src-ghc/GHCJS/Marshal/Internal.hs
+++ b/jsaddle/src-ghc/GHCJS/Marshal/Internal.hs
@@ -61,12 +61,21 @@ class ToJSVal a where
   default toJSVal :: (Generic a, GToJSVal (Rep a ())) => a -> JSM JSVal
   toJSVal = toJSVal_generic id
 
+instance ToJSVal (SomeJSArray Immutable) where
+  toJSVal (SomeJSArray x) = pure x
+
 fromJustWithStack :: JSadddleHasCallStack => Maybe a -> a
 fromJustWithStack Nothing = error "fromJSValUnchecked: fromJSVal result was Nothing"
 fromJustWithStack (Just x) = x
 
 class FromJSVal a where
   fromJSVal :: JSVal -> JSM (Maybe a)
+
+instance FromJSVal Function where
+  fromJSVal = pure . pure . Function . Object
+
+instance FromJSVal Object where
+  fromJSVal = pure . pure . Object
 
 #if MIN_VERSION_base(4,9,0) && defined(JSADDLE_HAS_CALL_STACK)
   fromJSValUnchecked :: JSadddleHasCallStack => JSVal -> JSM a

--- a/jsaddle/src/Language/Javascript/JSaddle/Classes/Internal.hs
+++ b/jsaddle/src/Language/Javascript/JSaddle/Classes/Internal.hs
@@ -21,7 +21,7 @@ module Language.Javascript.JSaddle.Classes.Internal (
 ) where
 
 import Language.Javascript.JSaddle.Types
-       (JSM, Object(..), JSVal)
+       (JSM, Object(..), JSVal, JSString(..), Function(..), Object(..))
 
 -- | Anything that can be used to make a JavaScript object reference
 class MakeObject this where
@@ -39,3 +39,14 @@ class MakeArgs this where
 instance MakeArgs arg => MakeArgs (JSM arg) where
     makeArgs arg = arg >>= makeArgs
 
+instance MakeArgs Int where
+  makeArgs arg = (:[]) <$> toJSVal arg
+
+instance MakeArgs Object where
+  makeArgs (Object arg) = pure [arg]
+
+instance MakeArgs JSString where
+  makeArgs (JSString arg) = makeArgs arg
+
+instance MakeArgs Function where
+  makeArgs (Function (Object arg)) = pure [arg]


### PR DESCRIPTION
This patch adds some basic instances to avoid orphans in downstream projects.