### PR TITLE
Fix Firefox compatibility

### DIFF
--- a/jsaddle-warp/src/Language/Javascript/JSaddle/WebSockets.hs
+++ b/jsaddle-warp/src/Language/Javascript/JSaddle/WebSockets.hs
@@ -224,6 +224,7 @@ jsaddleJs' jsaddleUri refreshOnLoad = "\
     "                return;\n\
     \            }\n\
     \\n\
+    \var initialSyncDepth = 0;\n\
     \ " <> runBatch (\a -> "ws.send(JSON.stringify(" <> a <> "));")
               (Just (\a -> "(function(){\n\
                   \                       var xhr = new XMLHttpRequest();\n\

--- a/jsaddle/src/Language/Javascript/JSaddle/Run/Files.hs
+++ b/jsaddle/src/Language/Javascript/JSaddle/Run/Files.hs
@@ -53,7 +53,7 @@ initState = "\
 
 runBatch :: (ByteString -> ByteString) -> Maybe (ByteString -> ByteString) -> ByteString
 runBatch send sendSync = "\
-    \  var runBatch = function(firstBatch, initialSyncDepth) {\n\
+    \  var runBatch = function(firstBatch) {\n\
     \    var processBatch = function(timestamp) {\n\
     \      var batch = firstBatch;\n\
     \      var callbacksToFree = [];\n\
@@ -153,7 +153,8 @@ runBatch send sendSync = "\
         "                                        if(inCallback > 0) {\n\
         \                                          " <> send "{\"tag\": \"Callback\", \"contents\": [lastResults[0], lastResults[1], nFunction, nFunctionInFunc, nThis, args]}" <> "\n\
         \                                        } else {\n\
-        \                                          runBatch(" <> s "{\"tag\": \"Callback\", \"contents\": [lastResults[0], lastResults[1], nFunction, nFunctionInFunc, nThis, args]}" <> ", 1);\n\
+        \                                          initialSyncDepth = 1;\n\
+        \                                          runBatch(" <> s "{\"tag\": \"Callback\", \"contents\": [lastResults[0], lastResults[1], nFunction, nFunctionInFunc, nThis, args]}" <> ");\n\
         \                                        }\n"
       Nothing ->
         "                                        " <> send "{\"tag\": \"Callback\", \"contents\": [lastResults[0], lastResults[1], nFunction, nFunctionInFunc, nThis, args]}" <> "\n"
@@ -336,6 +337,7 @@ runBatch send sendSync = "\
     \        processBatch(globalThis.performance ? globalThis.performance.now() : null);\n\
     \    }\n\
     \  };\n\
+    \  initialSyncDepth = 0;\n\
     \  runBatch(batch);\n\
     \"
 


### PR DESCRIPTION
It turns out that the original code was relying on V8 specific scoping behavior. The value of the argument `initialSyncDepth` was being set to `1` even when the other arguments inside `runBatch` were being evaluated and eventually calling `runBatch` again. So if I were do make a rough trace:

1. `<some function>`
2. call to `runBatch` with `initialSyncDepth` set to `1`
3. evaluation of `firstBatch` argument of `runBatch`
4. `<some code>`
5. another call to `runBatch` with no `initialSyncDepth` set
    ^ here is where the difference manifests, in Firefox the value of `initialSyncDepth` as seen by the nested call to `runBatch` will be `undefined`. However in V8 it will be `1` as the call to `runBatch` in 2 is still in progress technically.

This difference would lead to desync between the server side and the frontend JS code, which manifests as "spinning" in a tight loop as the frontend is trying to fetch an event that doesn't exist.

Properly fixes #54  and maybe also #64, while also retaining V8 compatibility as far as I can tell.

I tracked this down by running the same JSaddle program in both Firefox and ungoogled-chromium and stepping both in tandem with the respective debuggers until i found a difference. 