### PR TITLE
Link test suite against threaded runtime

### DIFF
--- a/jsaddle-warp/jsaddle-warp.cabal
+++ b/jsaddle-warp/jsaddle-warp.cabal
@@ -134,7 +134,7 @@ test-suite spec
       Language.Javascript.JSaddleSpec
   hs-source-dirs:
       tests
-  ghc-options: -Wall
+  ghc-options: -Wall -threaded
   build-depends:
       base
     , bytestring


### PR DESCRIPTION
Fixes
```
GHC.Internal.Event.Thread.getSystemTimerManager: the TimerManager requires linking against the threaded runtime
```
needed due to
https://github.com/yesodweb/wai/tree/8573a706d051648811753fb48c59507dcf1c4232/time-manager#warnings