### PR TITLE
Add Windows WebView2 backend, port jsaddle-webkitgtk to GTK4/WebKitGTK 6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ cabal-dev
 /.stack-work/
 *.project.local
 .idea/
+/result*

--- a/cabal.project
+++ b/cabal.project
@@ -1,16 +1,21 @@
+-- All packages are listed unconditionally: cabal.project `if os(...)`
+-- conditionals do NOT apply to `packages:` fields (they are silently
+-- ignored), so platform gating lives in each package's .cabal file as
+-- `buildable: False` guards instead.  The solver ignores dependencies of
+-- non-buildable components, so this solves on every platform.
 packages:
  jsaddle/
  jsaddle-warp/
  jsaddle-clib/
  jsaddle-terminal/
+ jsaddle-wkwebview/
+ jsaddle-webkitgtk/
+ jsaddle-webview2/
 
-if os(osx)
-  packages:
-    jsaddle-wkwebview/
-
-if os(linux)
-  packages:
-    jsaddle-webkit2gtk/
+-- jsaddle-webkit2gtk/ is not in the project: it needs webkit2gtk-4.0, which
+-- has been removed from nixpkgs (only 4.1 and 6.0 remain), and the solver
+-- rejects it whenever the pkg-config package is absent (a buildable: guard
+-- cannot express that).  jsaddle-webkitgtk (GTK4 + WebKitGTK 6.0) replaces it.
 
 constraints: haskell-gi-overloading == 0.0
 

--- a/flake.lock
+++ b/flake.lock
@@ -16,23 +16,6 @@
         "type": "github"
       }
     },
-    "cabal-32": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1603716527,
-        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.2",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
     "cabal-34": {
       "flake": false,
       "locked": {
@@ -118,31 +101,14 @@
         "type": "github"
       }
     },
-    "ghc-8.6.5-iohk": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1600920045,
-        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
-        "owner": "input-output-hk",
-        "repo": "ghc",
-        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "release/8.6.5-iohk",
-        "repo": "ghc",
-        "type": "github"
-      }
-    },
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1745454330,
-        "narHash": "sha256-MA9xYIHwc1JcffoUx1toBCpcmmx1MYqi4Ds9n+iP8Ig=",
+        "lastModified": 1783213527,
+        "narHash": "sha256-59GTsLh3xGNAIYF9J4THH+vIY5nI/oltJyP/DSOj3Jc=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "989ae6c63d1f2fcee69aa7f126010ac5844e1637",
+        "rev": "2be4d3ec00120b314cf9dfe361a76cdac061039a",
         "type": "github"
       },
       "original": {
@@ -154,11 +120,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1745454319,
-        "narHash": "sha256-SCBdlrFg1TmVqrrM6UWLuE+dhfDV5cKrNgdFTaR91gE=",
+        "lastModified": 1783212508,
+        "narHash": "sha256-6u93kXG5PTlOpE8S5BZma9UaBi1k3/PjDRzoRXDamaE=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "cfa745733399e92f1214d94e26e22f9f721702ba",
+        "rev": "401b02c3bb3a01bc14dbba5c497ff1501bcdda62",
         "type": "github"
       },
       "original": {
@@ -168,14 +134,30 @@
         "type": "github"
       }
     },
+    "hackage-internal": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750307553,
+        "narHash": "sha256-iiafNoeLHwlSLQTyvy8nPe2t6g5AV4PPcpMeH/2/DLs=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "f7867baa8817fab296528f4a4ec39d1c7c4da4f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
     "haskell-ci": {
       "flake": false,
       "locked": {
-        "lastModified": 1743351534,
-        "narHash": "sha256-oowOok6+RLk7n6vHWwYufxyUmUpun/VMo8hXpfm1+d8=",
+        "lastModified": 1782299874,
+        "narHash": "sha256-sQNh/Zd1S0fNe/ietbCvyqg+0/tglRyCmFPb3AD/5wc=",
         "owner": "haskell-CI",
         "repo": "haskell-ci",
-        "rev": "f0fd898ab14070fa46e9fd542a2b487a8146d88e",
+        "rev": "42a102e53821381a5f47bdeeadd775cf649c76df",
         "type": "github"
       },
       "original": {
@@ -187,18 +169,19 @@
     "haskellNix": {
       "inputs": {
         "HTTP": "HTTP",
-        "cabal-32": "cabal-32",
         "cabal-34": "cabal-34",
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
         "hackage": "hackage",
         "hackage-for-stackage": "hackage-for-stackage",
+        "hackage-internal": "hackage-internal",
         "hls": "hls",
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
         "hls-2.10": "hls-2.10",
+        "hls-2.11": "hls-2.11",
+        "hls-2.12": "hls-2.12",
         "hls-2.2": "hls-2.2",
         "hls-2.3": "hls-2.3",
         "hls-2.4": "hls-2.4",
@@ -217,16 +200,18 @@
         "nixpkgs-2311": "nixpkgs-2311",
         "nixpkgs-2405": "nixpkgs-2405",
         "nixpkgs-2411": "nixpkgs-2411",
+        "nixpkgs-2505": "nixpkgs-2505",
+        "nixpkgs-2511": "nixpkgs-2511",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1745455900,
-        "narHash": "sha256-H2EyIfyi9PsTARBzsjwfyPgniFgPOQLAX8nkrvKMQOU=",
+        "lastModified": 1783248820,
+        "narHash": "sha256-dkh5dJ/2VFOD26eSFAA9RqauKLKoHYGe66MX5bvcBWc=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "cafa5223a5411fa7545f21d76e9b8743f4d00c29",
+        "rev": "797416cdd72f57a8884c34548aa5f1a833538f80",
         "type": "github"
       },
       "original": {
@@ -298,6 +283,40 @@
       "original": {
         "owner": "haskell",
         "ref": "2.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.11": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747306193,
+        "narHash": "sha256-/MmtpF8+FyQlwfKHqHK05BdsxC9LHV70d/FiMM7pzBM=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "46ef4523ea4949f47f6d2752476239f1c6d806fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.12": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1758709460,
+        "narHash": "sha256-xkI8MIIVEVARskfWbGAgP5sHG/lyeKnkm0LIOJ19X5w=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "7d983de4fa7ff54369f6dd31444bdb9869aec83e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.12.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -457,11 +476,11 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1742121966,
-        "narHash": "sha256-x4bg4OoKAPnayom0nWc0BmlxgRMMHk6lEPvbiyFBq1s=",
+        "lastModified": 1778457436,
+        "narHash": "sha256-bzZAHGzwcQGzBTipJuUs9tvMGO28kp0373zqnpn0g5A=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "e9dc86ed6ad71f0368c16672081c8f26406c3a7e",
+        "rev": "8cdc446f8e2d91b120ecc075063e9475d387df52",
         "type": "github"
       },
       "original": {
@@ -521,11 +540,11 @@
     },
     "nixpkgs-2411": {
       "locked": {
-        "lastModified": 1739151041,
-        "narHash": "sha256-uNszcul7y++oBiyYXjHEDw/AHeLNp8B6pyWOB+RLA/4=",
+        "lastModified": 1751290243,
+        "narHash": "sha256-kNf+obkpJZWar7HZymXZbW+Rlk3HTEIMlpc6FCNz0Ds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "94792ab2a6beaec81424445bf917ca2556fbeade",
+        "rev": "5ab036a8d97cb9476fbe81b09076e6e91d15e1b6",
         "type": "github"
       },
       "original": {
@@ -535,13 +554,45 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable": {
+    "nixpkgs-2505": {
       "locked": {
-        "lastModified": 1737110817,
-        "narHash": "sha256-DSenga8XjPaUV5KUFW/i3rNkN7jm9XmguW+qQ1ZJTR4=",
+        "lastModified": 1764560356,
+        "narHash": "sha256-M5aFEFPppI4UhdOxwdmceJ9bDJC4T6C6CzCK1E2FZyo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "041c867bad68dfe34b78b2813028a2e2ea70a23c",
+        "rev": "6c8f0cca84510cc79e09ea99a299c9bc17d03cb6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2511": {
+      "locked": {
+        "lastModified": 1775749320,
+        "narHash": "sha256-msT6frWJSQ2WR+0cpk+KPcZdLTLagUIsJwQwIX9JNSo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "74b87959b2d16f59f54d8559cf3cf26b9d907949",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
         "type": "github"
       },
       "original": {
@@ -582,11 +633,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1745453555,
-        "narHash": "sha256-UdWBshU4hyz5Q76yqxvkhbc+ywAYeQtrigyUnOGTaV4=",
+        "lastModified": 1783125105,
+        "narHash": "sha256-9D4GhTwfL6zQJ+wUzyys6nxTX8314hihbxf/V9M8azY=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "077ab84d76fdcd96ba879b135f35c1edb853fcd2",
+        "rev": "bdfd849b76c38bcf4f916fb17478e40287ac2449",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -29,8 +29,19 @@
         ];
         pkgs = import nixpkgs { inherit system overlays; inherit (haskellNix) config; };
         flake = pkgs.hixProject.flake {};
+        # Runtime smoke test for the WebKitGTK backend (linux-only, headless).
+        extraChecks = pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+          webkitgtk-smoke = pkgs.callPackage ./nix/webkitgtk-smoke.nix {
+            jsaddle-webkitgtk-demo =
+              flake.packages."jsaddle-webkitgtk:exe:jsaddle-webkitgtk-demo";
+          };
+        };
       in flake // {
         legacyPackages = pkgs;
+        checks = flake.checks // extraChecks;
+        hydraJobs = flake.hydraJobs // {
+          checks = (flake.hydraJobs.checks or {}) // extraChecks;
+        };
       });
 
   # --- Flake Local Nix Configuration ----------------------------

--- a/jsaddle-terminal/jsaddle-terminal.cabal
+++ b/jsaddle-terminal/jsaddle-terminal.cabal
@@ -18,6 +18,14 @@ description:
   clickable URL.
 build-type:         Simple
 
+flag demo
+  description:
+    Build the jsaddle-terminal-demo executable.  Off by default: it needs
+    reflex-dom-core, whose released versions lag new GHCs (base upper
+    bounds), which would break solving the whole project on those GHCs.
+  default: False
+  manual: True
+
 library
   hs-source-dirs:     src
   exposed-modules:    Language.Javascript.JSaddle.Terminal
@@ -36,6 +44,9 @@ library
                     , websockets
   ghc-options:        -Wall
   default-language:   Haskell2010
+  -- Raw-mode stdin/termios: POSIX only.
+  if os(windows)
+    buildable: False
 
 executable jsaddle-terminal-demo
   main-is:            Main.hs
@@ -50,6 +61,8 @@ executable jsaddle-terminal-demo
                     , text
   ghc-options:        -threaded -Wall
   default-language:   Haskell2010
+  if os(windows) || !flag(demo)
+    buildable: False
 
 test-suite jsaddle-terminal-test
   type:               exitcode-stdio-1.0
@@ -60,3 +73,5 @@ test-suite jsaddle-terminal-test
                     , jsaddle-terminal
   ghc-options:        -Wall
   default-language:   Haskell2010
+  if os(windows)
+    buildable: False

--- a/jsaddle-webkit2gtk/jsaddle-webkit2gtk.cabal
+++ b/jsaddle-webkit2gtk/jsaddle-webkit2gtk.cabal
@@ -44,6 +44,10 @@ library
     if !os(windows)
       build-depends:
         unix >=2.3.1.0 && <2.9
+    -- Native builds need webkit2gtk (gi-webkit2): Linux only.
+    -- (The ghcjs/javascript branch builds anywhere.)
+    if !os(linux) && !impl(ghcjs) && !arch(javascript)
+      buildable: False
     default-language: Haskell2010
     hs-source-dirs: src
     ghc-options: -ferror-spans -Wall

--- a/jsaddle-webkitgtk/demo/Main.hs
+++ b/jsaddle-webkitgtk/demo/Main.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ExtendedDefaultRules #-}
+{-# OPTIONS_GHC -Wno-type-defaults #-}
+-- | Minimal jsaddle-webkitgtk demo: a click counter (exercises the
+--   synchronous prompt bridge via the callback) and an uptime ticker
+--   (exercises async batches from a background Haskell thread).
+--
+--   With @--smoke@ it also asserts a full round trip through the bridge
+--   (async eval + result, and a Haskell callback invoked from JS) and
+--   exits 0/1 — suitable for headless CI under @xvfb-run@.
+module Main (main) where
+
+import Control.Concurrent (forkIO, threadDelay)
+import Control.Monad (forever, void, when)
+import Control.Monad.IO.Class (liftIO)
+import Data.IORef (atomicModifyIORef', newIORef, readIORef, writeIORef)
+import qualified Data.Text as T
+import System.Environment (getArgs)
+import System.Exit (ExitCode(..))
+import System.IO (hSetBuffering, stdout, BufferMode(LineBuffering))
+import System.Posix.Process (exitImmediately)
+import Language.Javascript.JSaddle
+import Language.Javascript.JSaddle.WebKitGTK (run)
+
+main :: IO ()
+main = do
+    hSetBuffering stdout LineBuffering
+    smoke <- elem "--smoke" <$> getArgs
+    -- exitImmediately: exitSuccess/exitFailure only throw in the calling
+    -- thread, and everything here runs off the GTK main loop's thread.
+    when smoke . void . forkIO $ do
+        threadDelay 60000000
+        putStrLn "SMOKE-TIMEOUT"
+        exitImmediately (ExitFailure 1)
+    run $ do
+        doc <- jsg "document"
+        body <- doc ! "body"
+        void $ body # "insertAdjacentHTML" $
+            ( "beforeend"
+            , "<h1>jsaddle-webkitgtk demo</h1>\
+              \<p>Uptime: <span id=\"uptime\">0</span>s</p>\
+              \<p><button id=\"btn\">Clicked <span id=\"count\">0</span> times</button></p>"
+            )
+
+        clicks <- liftIO $ newIORef (0 :: Int)
+        btn <- doc # "getElementById" $ ["btn"]
+        void $ btn # "addEventListener" $
+            ( "click"
+            , fun $ \_ _ _ -> do
+                n <- liftIO $ atomicModifyIORef' clicks $ \c -> (c + 1, c + 1)
+                el <- doc # "getElementById" $ ["count"]
+                el <# "textContent" $ T.pack (show n)
+            )
+
+        seconds <- liftIO $ newIORef (0 :: Int)
+        ctx <- askJSM
+        void . liftIO . forkIO . forever $ do
+            threadDelay 1000000
+            s <- atomicModifyIORef' seconds $ \c -> (c + 1, c + 1)
+            runJSaddle ctx $ do
+                el <- jsg "document" # "getElementById" $ ["uptime"]
+                el <# "textContent" $ T.pack (show s)
+
+        when smoke $ do
+            v <- eval "6 * 7"
+            n <- valToNumber v
+            liftIO . putStrLn $ "SMOKE eval 6*7 = " ++ show n
+            -- A Haskell callback invoked from an eval'd script goes through
+            -- the synchronous JSaddleSync prompt path.
+            got <- liftIO $ newIORef (0 :: Double)
+            _ <- jsg "globalThis" <# "hsSmoke" $ fun $ \_ _ as -> case as of
+                (a:_) -> valToNumber a >>= liftIO . writeIORef got
+                _     -> return ()
+            _ <- eval "globalThis.hsSmoke(123)"
+            syncPoint
+            liftIO $ do
+                -- callbacks run on forked threads; give it a moment
+                let waitCb 0 = readIORef got
+                    waitCb k = do
+                        x <- readIORef got
+                        if x == 123 then return x
+                                    else threadDelay 100000 >> waitCb (k - 1 :: Int)
+                x <- waitCb 100
+                putStrLn $ "SMOKE callback got " ++ show x
+                if n == 42 && x == 123
+                    then putStrLn "SMOKE-OK" >> exitImmediately ExitSuccess
+                    else putStrLn "SMOKE-FAIL" >> exitImmediately (ExitFailure 1)

--- a/jsaddle-webkitgtk/jsaddle-webkitgtk.cabal
+++ b/jsaddle-webkitgtk/jsaddle-webkitgtk.cabal
@@ -1,5 +1,5 @@
 name: jsaddle-webkitgtk
-version: 0.9.0.0
+version: 0.9.9.3
 cabal-version: >=1.10
 build-type: Simple
 license: MIT
@@ -7,10 +7,10 @@ license-file: LICENSE
 maintainer: Hamish Mackenzie <Hamish.K.Mackenzie@googlemail.com>
 synopsis: Interface for JavaScript that works with GHCJS and GHC
 description:
-    This package provides an EDSL for calling JavaScript that
-    can be used both from GHCJS and GHC.  When using GHC
-    the application is run using Warp and WebSockets to
-    drive a small JavaScipt helper.
+    jsaddle backend hosting the app in a GTK4 window containing a
+    WebKitGTK 6.0 WebView (gi-gtk4 / gi-webkit 6.x).  The modern
+    replacement for jsaddle-webkit2gtk (GTK3 / webkit2gtk 4.0, which has
+    been removed from nixpkgs).
 category: Web, Javascript
 author: Hamish Mackenzie
 
@@ -23,22 +23,42 @@ library
     exposed-modules:
         Language.Javascript.JSaddle.WebKitGTK
     build-depends:
-        aeson >=0.8.0.2 && <1.3,
-        base <5,
-        bytestring >=0.10.6.0 && <0.11,
+        base <5
+    if !impl(ghcjs -any) && !arch(javascript)
+      build-depends:
+        aeson >=0.8.0.2 && <2.3,
+        bytestring >=0.10.6.0 && <0.13,
         directory >=1.0.0.2 && <1.4,
-        gi-glib >=2.0.6 && <2.1,
-        gi-gtk >=3.0.6 && <3.1,
-        gi-webkit >=3.0.6 && <3.1,
-        gi-javascriptcore >=3.0.6 && <3.1,
-        haskell-gi-base >=0.20 && <0.21,
-        jsaddle >=0.9.0.0 && <0.10,
-        text >=1.2.1.3 && <1.3 || >= 2.0 && < 2.1,
-        webkitgtk3-javascriptcore >=0.14.0.0 && <0.15
+        gi-glib >=2.0.14 && <2.1,
+        gi-gio >=2.0.14 && <2.1,
+        gi-gtk4 >=4.0.8 && <4.1,
+        gi-webkit >=6.0.2 && <6.1,
+        gi-javascriptcore6 >=6.0.2 && <6.1,
+        haskell-gi-base >=0.26 && <0.27,
+        jsaddle >=0.9.9.0 && <0.10,
+        text >=1.2.1.3 && <1.3 || >= 2.0 && < 2.2
     if !os(windows)
       build-depends:
-        unix >=2.3.1.0 && <2.8
+        unix >=2.3.1.0 && <2.9
+    -- Native builds need webkitgtk 6.0 (GTK4): Linux only.
+    -- (The ghcjs/javascript stub builds anywhere.)
+    if !os(linux) && !impl(ghcjs) && !arch(javascript)
+      buildable: False
     default-language: Haskell2010
     hs-source-dirs: src
     ghc-options: -ferror-spans -Wall
 
+executable jsaddle-webkitgtk-demo
+    main-is: Main.hs
+    hs-source-dirs: demo
+    build-depends:
+        base <5,
+        jsaddle,
+        jsaddle-webkitgtk,
+        text,
+        unix
+    -- Native-only (no ghcjs stub): a plain WebKitGTK window app.
+    if !os(linux)
+      buildable: False
+    default-language: Haskell2010
+    ghc-options: -ferror-spans -Wall -threaded

--- a/jsaddle-webkitgtk/src/Language/Javascript/JSaddle/WebKitGTK.hs
+++ b/jsaddle-webkitgtk/src/Language/Javascript/JSaddle/WebKitGTK.hs
@@ -3,15 +3,16 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MonoLocalBinds #-}
 -----------------------------------------------------------------------------
 --
--- Module      :  Language.Javascript.JSaddle.WebSockets
+-- Module      :  Language.Javascript.JSaddle.WebKitGTK
 -- Copyright   :  (c) Hamish Mackenzie
 -- License     :  MIT
 --
 -- Maintainer  :  Hamish Mackenzie <Hamish.K.Mackenzie@googlemail.com>
 --
--- |
+-- | Run jsaddle apps in a GTK4 window hosting a WebKitGTK 6.0 WebView.
 --
 -----------------------------------------------------------------------------
 module Language.Javascript.JSaddle.WebKitGTK (
@@ -30,9 +31,7 @@ run = id
 
 #else
 
-import Control.Monad (when, void)
-import qualified Control.Exception as E (catch)
-import Control.Exception (SomeException(..))
+import Control.Monad (void)
 import Control.Concurrent (forkIO, yield)
 
 #ifndef mingw32_HOST_OS
@@ -40,191 +39,128 @@ import System.Posix.Signals (installHandler, keyboardSignal, Handler(Catch))
 #endif
 import System.Directory (getCurrentDirectory)
 
-import Data.Monoid ((<>))
 import Data.ByteString.Lazy (toStrict, fromStrict)
 import qualified Data.ByteString.Lazy as LB (ByteString)
 import Data.Aeson (encode, decode)
-import Data.Text (Text)
-import qualified Data.Text as T (unpack, pack)
-import Data.Text.Foreign (useAsPtr, fromPtr)
+import qualified Data.Text as T (pack)
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 
-import Foreign.Ptr (castPtr, nullPtr)
-import Foreign.Marshal.Array (withArray, peekArray)
-import Foreign.Storable (Storable(..))
-import Foreign.Marshal.Alloc (alloca)
-
-import Data.GI.Base.ManagedPtr (withManagedPtr)
 import GI.GLib
-       (timeoutAdd, idleAdd, pattern PRIORITY_HIGH, pattern PRIORITY_DEFAULT)
-import qualified GI.Gtk as Gtk (main, init)
+       (timeoutAdd, idleAdd, mainLoopNew, mainLoopRun, mainLoopQuit,
+        pattern PRIORITY_HIGH, pattern PRIORITY_DEFAULT)
+import qualified GI.Gtk as Gtk (init)
 import GI.Gtk
-       (windowSetPosition, windowSetDefaultSize, windowNew, scrolledWindowNew,
-        noAdjustment, containerAdd, WindowType(..), WindowPosition(..),
-        widgetDestroy, widgetGetToplevel, widgetShowAll, onWidgetDestroy,
-        mainQuit)
-import GI.JavaScriptCore.Structs.GlobalContext (GlobalContext(..))
+       (Window, windowNew, windowSetDefaultSize, windowSetChild,
+        windowPresent, windowDestroy, scrolledWindowNew,
+        scrolledWindowSetChild, onWidgetDestroy)
+import GI.Gio (Cancellable)
+import GI.JavaScriptCore (valueToString)
 import GI.WebKit
-       (WebView, webViewGetMainFrame, webFrameGetGlobalContext,
-        onWebInspectorInspectWebView, webViewGetInspector, webViewSetSettings,
-        setWebSettingsEnableDeveloperExtras,
-        setWebSettingsEnableUniversalAccessFromFileUris,
-        webViewGetSettings, webViewNew, onWebViewLoadFinished,
-        webViewLoadString)
+       (scriptDialogPromptSetText, scriptDialogPromptGetDefaultText,
+        scriptDialogGetMessage, scriptDialogGetDialogType,
+        onWebViewScriptDialog, WebView, webViewNew,
+        setSettingsEnableWriteConsoleMessagesToStdout,
+        setSettingsEnableJavascript,
+        onUserContentManagerScriptMessageReceived,
+        userContentManagerRegisterScriptMessageHandler,
+        webViewGetUserContentManager,
+        webViewEvaluateJavascript, LoadEvent(..), webViewLoadHtml,
+        onWebViewLoadChanged, setSettingsEnableDeveloperExtras,
+        webViewSetSettings, webViewGetSettings, ScriptDialogType(..))
 
-import Graphics.UI.Gtk.WebKit.JavaScriptCore.JSBase
-       (JSValueRef, JSValueRefRef, JSObjectRef, JSContextRef,
-        jsevaluatescript, JSStringRef)
-import Graphics.UI.Gtk.WebKit.JavaScriptCore.JSStringRef
-       (jsstringretain, jsstringrelease, jsstringgetcharactersptr,
-        jsstringgetlength, jsstringcreatewithcharacters)
-import Graphics.UI.Gtk.WebKit.JavaScriptCore.JSObjectRef
-       (jsobjectcallasfunction, JSCSize, jsobjectsetproperty,
-        jsobjectmakefunctionwithcallback, mkJSObjectCallAsFunctionCallback)
-import Graphics.UI.Gtk.WebKit.JavaScriptCore.JSContextRef
-       (jscontextgetglobalobject)
-import Graphics.UI.Gtk.WebKit.JavaScriptCore.JSValueRef
-       (jsvalueprotect, jsvalueunprotect,
-        jsvaluetostringcopy, jsvaluemakestring, jsvaluemakeundefined)
-
-import Language.Javascript.JSaddle (JSM, Results)
+import Language.Javascript.JSaddle (JSM, Results, Batch)
 import Language.Javascript.JSaddle.Run (runJavaScript)
 import Language.Javascript.JSaddle.Run.Files (initState, runBatch, ghcjsHelpers)
 
-quitWebView :: WebView -> IO ()
-quitWebView wv = postGUIAsync $ do w <- widgetGetToplevel wv --TODO: Shouldn't this be postGUISync?
-                                   widgetDestroy w
+noCancellable :: Maybe Cancellable
+noCancellable = Nothing
 
-installQuitHandler :: WebView -> IO ()
+quitWindow :: Window -> IO ()
+quitWindow window = postGUIAsync $ windowDestroy window
+
+installQuitHandler :: Window -> IO ()
 #ifdef mingw32_HOST_OS
-installQuitHandler wv = return () -- TODO: Maybe figure something out here for Windows users.
+installQuitHandler _ = return () -- TODO: Maybe figure something out here for Windows users.
 #else
-installQuitHandler wv = void $ installHandler keyboardSignal (Catch (quitWebView wv)) Nothing
+installQuitHandler window = void $ installHandler keyboardSignal (Catch (quitWindow window)) Nothing
 #endif
 
 postGUIAsync :: IO () -> IO ()
 postGUIAsync action =
   void . idleAdd PRIORITY_DEFAULT $ action >> return False
 
-withJSString :: Text -> (JSStringRef -> IO a) -> IO a
-withJSString s f = do
-    jsstring <- useAsPtr s $ \p l -> jsstringcreatewithcharacters (castPtr p) (fromIntegral l)
-    _ <- jsstringretain jsstring
-    result <- f jsstring
-    jsstringrelease jsstring
-    return result
-
-withJSContextRef :: GlobalContext -> (JSContextRef -> IO a) -> IO a
-withJSContextRef (GlobalContext ctx) f = withManagedPtr ctx (f . castPtr)
-
-valueToText :: JSContextRef -> JSValueRef -> IO Text
-valueToText ctxRef s = do
-    jsstring <- jsvaluetostringcopy ctxRef s nullPtr
-    l <- jsstringgetlength jsstring
-    p <- jsstringgetcharactersptr jsstring
-    result <- fromPtr (castPtr p) (fromIntegral l)
-    jsstringrelease jsstring
-    return result
-
-check :: JSContextRef -> (JSValueRefRef -> IO a) -> IO a
-check ctxRef f =
-    alloca $ \exceptionPtr -> do
-        poke exceptionPtr nullPtr
-        result <- f exceptionPtr
-        exception <- peek exceptionPtr
-        when (exception /= nullPtr) $ do
-            errorText <- valueToText ctxRef exception
-            error $ T.unpack errorText
-        return result
-
-eval :: JSContextRef -> Text -> IO JSValueRef
-eval ctxRef script =
-    withJSString script $ \script' ->
-        check ctxRef $ jsevaluatescript ctxRef script' nullPtr nullPtr 0
-
 run :: JSM () -> IO ()
 run main = do
-    _ <- Gtk.init Nothing
-    window <- windowNew WindowTypeToplevel
+    Gtk.init
+    loop <- mainLoopNew Nothing False
     _ <- timeoutAdd PRIORITY_HIGH 10 (yield >> return True)
+    window <- windowNew
     windowSetDefaultSize window 900 600
-    windowSetPosition window WindowPositionCenter
-    scrollWin <- scrolledWindowNew noAdjustment noAdjustment
+    scrollWin <- scrolledWindowNew
     webView <- webViewNew
     settings <- webViewGetSettings webView
-    setWebSettingsEnableUniversalAccessFromFileUris settings True
-    setWebSettingsEnableDeveloperExtras settings True
+    setSettingsEnableDeveloperExtras settings True
+    setSettingsEnableJavascript settings True
+    setSettingsEnableWriteConsoleMessagesToStdout settings True
     webViewSetSettings webView settings
-    window `containerAdd` scrollWin
-    scrollWin `containerAdd` webView
-    _ <- onWidgetDestroy window mainQuit
-    widgetShowAll window
-    inspector <- webViewGetInspector webView
-    _ <- onWebInspectorInspectWebView inspector $ \_ -> do
-        inspectorWindow <- windowNew WindowTypeToplevel
-        windowSetDefaultSize inspectorWindow 900 600
-        inspectorScrollWin <- scrolledWindowNew noAdjustment noAdjustment
-        inspectorWebView <- webViewNew
-        inspectorWindow `containerAdd` inspectorScrollWin
-        inspectorScrollWin `containerAdd` inspectorWebView
-        widgetShowAll inspectorWindow
-        return inspectorWebView
+    scrolledWindowSetChild scrollWin (Just webView)
+    windowSetChild window (Just scrollWin)
+    _ <- onWidgetDestroy window $ mainLoopQuit loop
+    windowPresent window
     pwd <- getCurrentDirectory
-    void . onWebViewLoadFinished webView $ \ _ ->
-        runInWebView main webView
-    webViewLoadString webView "" "text/html" "UTF-8" $ "file://" <> T.pack pwd <> "/"
-    installQuitHandler webView
-    Gtk.main
+    let webViewLoadChangedCallback LoadEventFinished = runInWebView main webView
+        webViewLoadChangedCallback _                 = return ()
+    _ <- onWebViewLoadChanged webView webViewLoadChangedCallback
+    webViewLoadHtml webView "" . Just $ "file://" <> T.pack pwd <> "/index.html"
+    installQuitHandler window
+    mainLoopRun loop
 
 runInWebView :: JSM () -> WebView -> IO ()
 runInWebView f webView = do
-    ctx <- webViewGetMainFrame webView >>= webFrameGetGlobalContext
-    runJSaddleBatch <-
-        withJSContextRef ctx $ \ctxRef -> do
-            result <- eval ctxRef (decodeUtf8 $ toStrict jsaddleJs)
-            jsvalueprotect ctxRef result
-            return result
-
-    (processResults, _, start) <- runJavaScript (\batch -> postGUIAsync $
-        withJSContextRef ctx $ \ctxRef ->
-            withJSString (decodeUtf8 . toStrict $ encode batch) $ \script -> do
-                val <- jsvaluemakestring ctxRef script
-                withArray [val] $ \args ->
-                    void . check ctxRef $ jsobjectcallasfunction ctxRef runJSaddleBatch nullPtr 1 args
-                jsvalueunprotect ctxRef val)
+    (processResults, syncResults, start) <- runJavaScript (\batch -> postGUIAsync $
+        webViewEvaluateJavascript webView
+            (decodeUtf8 . toStrict $ "runJSaddleBatch(" <> encode batch <> ");")
+            (-1) Nothing Nothing noCancellable Nothing)
         f
 
-    withJSContextRef ctx $ \ctxRef -> do
-        addJSaddleHandler ctxRef processResults
-        void $ forkIO start
+    addJSaddleHandler webView processResults syncResults
+    webViewEvaluateJavascript webView (decodeUtf8 $ toStrict jsaddleJs)
+        (-1) Nothing Nothing noCancellable . Just $
+            \_obj _asyncResult ->
+                void $ forkIO start
 
-addJSaddleHandler :: JSContextRef -> (Results -> IO ()) -> IO ()
-addJSaddleHandler ctxRef processResult = do
-    callback <- mkJSObjectCallAsFunctionCallback wrap
-    function <- jsobjectmakefunctionwithcallback ctxRef nullPtr callback
-    global <- jscontextgetglobalobject ctxRef
-    withJSString "jsaddleCallback" $ \propName ->
-        jsobjectsetproperty ctxRef global propName function 0 nullPtr
-  where
-    wrap :: JSContextRef -> JSObjectRef -> JSObjectRef -> JSCSize -> JSValueRefRef -> JSValueRefRef -> IO JSValueRef
-    wrap _ctx _fobj _this argc argv exception = do
-            [arg] <- peekArray (fromIntegral argc) argv
-            bs <- encodeUtf8 <$> valueToText ctxRef arg
-            mapM_ processResult (decode (fromStrict bs))
-            jsvaluemakeundefined ctxRef
-      `E.catch` \(e :: SomeException) -> do
-            withJSString (T.pack (show e)) (jsvaluemakestring ctxRef) >>= poke exception
-            jsvaluemakeundefined ctxRef
+addJSaddleHandler :: WebView -> (Results -> IO ()) -> (Results -> IO Batch) -> IO ()
+addJSaddleHandler webView processResult syncResults = do
+    manager <- webViewGetUserContentManager webView
+    _ <- onUserContentManagerScriptMessageReceived manager Nothing $ \value -> do
+        bs <- encodeUtf8 <$> valueToString value
+        mapM_ processResult (decode (fromStrict bs))
+    _ <- onWebViewScriptDialog webView $ \dialog ->
+        scriptDialogGetDialogType dialog >>= \case
+            ScriptDialogTypePrompt ->
+                scriptDialogGetMessage dialog >>= \case
+                    "JSaddleSync" -> do
+                        resultsText <- scriptDialogPromptGetDefaultText dialog
+                        case decode (fromStrict $ encodeUtf8 resultsText) of
+                            Just results -> do
+                                batch <- syncResults results
+                                scriptDialogPromptSetText dialog (decodeUtf8 . toStrict $ encode batch)
+                                return True
+                            Nothing -> return False
+                    _ -> return False
+            _ -> return False
+
+    void $ userContentManagerRegisterScriptMessageHandler manager "jsaddle" Nothing
 
 jsaddleJs :: LB.ByteString
 jsaddleJs = ghcjsHelpers <> mconcat
-    [ "(function() {\n"
+    [ "runJSaddleBatch = (function() {\n"
     , initState
-    , "\nreturn function(batchJSON) {\n"
-    , "  var batch = JSON.parse(batchJSON);\n"
-    , runBatch (\a -> "window.jsaddleCallback(JSON.stringify(" <> a <> "));\n") Nothing
+    , "\nreturn function(batch) {\n"
+    , runBatch (\a -> "window.webkit.messageHandlers.jsaddle.postMessage(JSON.stringify(" <> a <> "));\n")
+               (Just (\a -> "JSON.parse(window.prompt(\"JSaddleSync\", JSON.stringify(" <> a <> ")))"))
     , "};\n"
-    , "})()\n"
+    , "})()"
     ]
 
 #endif

--- a/jsaddle-webview2/LICENSE
+++ b/jsaddle-webview2/LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) 2010-2012 Hamish Mackenzie, Victor Nazarov, Luite Stegeman
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/jsaddle-webview2/README.md
+++ b/jsaddle-webview2/README.md
@@ -1,0 +1,83 @@
+# jsaddle-webview2
+
+Run [jsaddle](../jsaddle) apps in a native Windows window hosting a Microsoft
+Edge **WebView2** control — the Windows sibling of
+[jsaddle-wkwebview](../jsaddle-wkwebview) (macOS/iOS, WebKit) and
+[jsaddle-webkit2gtk](../jsaddle-webkit2gtk) (Linux, WebKitGTK).
+
+```haskell
+import qualified Language.Javascript.JSaddle.WebView2 as WV2
+
+main :: IO ()
+main = WV2.run myJsmApp
+```
+
+## How it works
+
+The C shim (`cbits/WebView2Shim.c`, plain C COM against the official
+`WebView2.h`) creates a Win32 window, loads `WebView2Loader.dll` dynamically,
+creates the WebView2 environment/controller, and pumps the message loop.
+The jsaddle transport mirrors jsaddle-wkwebview exactly:
+
+* **Haskell → JS**: batches are `ExecuteScript`ed (marshalled to the UI
+  thread with `PostMessage`, since WebView2 is single-threaded).
+* **JS → Haskell (async)**: `window.chrome.webview.postMessage(...)` →
+  `WebMessageReceived`.
+* **JS → Haskell (sync)**: `window.prompt("JSaddleSync", <json>)`.  Default
+  script dialogs are disabled, so the `ScriptDialogOpening` event fires on
+  the UI thread while the page's JS is blocked in `prompt()`; the handler
+  calls into Haskell, which computes the reply batch, and completes the
+  dialog with `put_ResultText` + `Accept`.  (Same trick as wkwebview's
+  `runJavaScriptTextInputPanelWithPrompt` — which is why the WKWebView
+  `uiDelegate` must never be overridden there, and why default script
+  dialogs must stay disabled here.)
+
+## Build requirements
+
+Only `WebView2.h` (and the headers it includes) is needed at **compile**
+time; nothing from the WebView2 SDK is linked.  Get it from the
+[`Microsoft.Web.WebView2`](https://www.nuget.org/packages/Microsoft.Web.WebView2)
+NuGet package (it's a plain zip): `build/native/include/WebView2.h`.
+Point the include path at it, e.g. in `cabal.project`:
+
+```
+package jsaddle-webview2
+  extra-include-dirs: C:\path\to\webview2-sdk\build\native\include
+```
+
+With nix, a small `fetchzip` derivation does it (license: unfree but
+freely redistributable):
+
+```nix
+webview2-sdk = pkgs.fetchzip {
+  url = "https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/1.0.4022.49";
+  extension = "zip";
+  stripRoot = false;
+  hash = "...";
+};
+# then: extra-include-dirs = [ "${webview2-sdk}/build/native/include" ];
+```
+
+The header is MIDL-generated flat COM and compiles fine under **mingw-w64**
+(GHC's Windows toolchain) — no MSVC needed.
+
+## Runtime requirements
+
+* The **WebView2 runtime** — preinstalled on Windows 11, Evergreen-installed
+  on most Windows 10 machines ([bootstrapper](https://developer.microsoft.com/microsoft-edge/webview2/)
+  for the rest).
+* **`WebView2Loader.dll`** next to the executable — from the same NuGet
+  package (`runtimes/win-x64/native/WebView2Loader.dll`).  It is
+  `LoadLibrary`'d at startup, so no import library is needed at link time.
+
+## Notes and limitations
+
+* `runHTML` uses `NavigateToString`: page origin is `about:blank` and the
+  HTML is capped at 2MB.  Use `runURL` (e.g. a `file://` URL or
+  `SetVirtualHostNameToFolderMapping` in a future version) for real apps.
+* Page reloads are not supported (jsaddle state does not survive them);
+  only the first completed navigation starts the jsaddle app.
+* The user-data folder defaults to `%LOCALAPPDATA%\jsaddle-webview2`.
+* The sync bridge rides `window.prompt`, so apps must not intercept
+  `ScriptDialogOpening` themselves, and very large sync payloads depend on
+  Chromium passing dialog text through unclamped.

--- a/jsaddle-webview2/cbits/WebView2Shim.c
+++ b/jsaddle-webview2/cbits/WebView2Shim.c
@@ -495,5 +495,13 @@ int runJsaddleWebView2(HsStablePtr mainCallback, const char *title,
         TranslateMessage(&msg);
         DispatchMessageW(&msg);
     }
+
+    if (app->webview) ICoreWebView2_Release(app->webview);
+    if (app->controller) ICoreWebView2Controller_Release(app->controller);
+    free(app->syncResult);
+    free(app);
+    CoUninitialize();
+    FreeLibrary(loader);
+
     return (int)msg.wParam;
 }

--- a/jsaddle-webview2/cbits/WebView2Shim.c
+++ b/jsaddle-webview2/cbits/WebView2Shim.c
@@ -1,0 +1,499 @@
+/* jsaddle-webview2: host a jsaddle app in a Microsoft Edge WebView2 control.
+ *
+ * Plain C against the official WebView2.h (COBJMACROS / C-style COM).  The
+ * WebView2Loader.dll is loaded dynamically (LoadLibrary) so nothing from the
+ * WebView2 SDK is needed at link time -- only WebView2.h at compile time.
+ *
+ * Threading: WebView2 is single-threaded (STA).  Everything that touches
+ * ICoreWebView2* must run on the thread that created the controller -- the
+ * thread that called runJsaddleWebView2 and is pumping the message loop.
+ * Calls arriving from other (Haskell) threads are marshalled to it with
+ * PostMessage (the payload is a heap-allocated wide string freed by the
+ * window proc).
+ *
+ * The synchronous jsaddle bridge mirrors jsaddle-wkwebview: the page calls
+ * window.prompt("JSaddleSync", <Results JSON>); with default script dialogs
+ * disabled this raises ScriptDialogOpening on the UI thread while the page's
+ * JS is blocked, we call into Haskell (which computes the reply Batch and
+ * hands it back via completeSyncWV2 before returning), then put_ResultText +
+ * Accept complete the prompt with the Batch JSON.
+ */
+#define COBJMACROS
+#include <windows.h>
+#include <objbase.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "HsFFI.h"
+#include "WebView2.h"
+
+#define WM_JSADDLE_EVAL     (WM_APP + 1)
+#define WM_JSADDLE_NAV_URL  (WM_APP + 2)
+#define WM_JSADDLE_NAV_HTML (WM_APP + 3)
+
+typedef struct JSaddleWV2 {
+    HWND hwnd;
+    ICoreWebView2Controller *controller;
+    ICoreWebView2 *webview;
+    HsStablePtr mainCallback;
+    HsStablePtr startHandler;
+    HsStablePtr resultHandler;
+    HsStablePtr syncHandler;
+    int handlersSet;
+    int started;
+    int devTools;
+    char *syncResult; /* set by completeSyncWV2 inside jsaddleSyncResult */
+} JSaddleWV2;
+
+/* Haskell (foreign export ccall) */
+extern void jsaddleStart(HsStablePtr);
+extern void jsaddleResult(HsStablePtr, const char *);
+extern void jsaddleSyncResult(HsStablePtr, JSaddleWV2 *, const char *);
+extern void callWithWebView2(JSaddleWV2 *, HsStablePtr);
+
+/* ---------------------------------------------------------------- utf8 */
+
+static char *utf8FromWide(LPCWSTR w)
+{
+    if (!w) return NULL;
+    int n = WideCharToMultiByte(CP_UTF8, 0, w, -1, NULL, 0, NULL, NULL);
+    if (n <= 0) return NULL;
+    char *s = (char *)malloc((size_t)n);
+    if (s) WideCharToMultiByte(CP_UTF8, 0, w, -1, s, n, NULL, NULL);
+    return s;
+}
+
+static LPWSTR wideFromUtf8(const char *s)
+{
+    if (!s) return NULL;
+    int n = MultiByteToWideChar(CP_UTF8, 0, s, -1, NULL, 0);
+    if (n <= 0) return NULL;
+    LPWSTR w = (LPWSTR)malloc((size_t)n * sizeof(WCHAR));
+    if (w) MultiByteToWideChar(CP_UTF8, 0, s, -1, w, n);
+    return w;
+}
+
+/* ------------------------------------------------- generic COM handler
+ * Every callback interface WebView2 hands us is IUnknown + one Invoke, so a
+ * single struct layout covers them all; only the Invoke slot differs.
+ * QueryInterface accepts any IID: WebView2 only ever asks for the interface
+ * it was given (or IUnknown), and we have no IID table to compare against
+ * without dragging in a MIDL-generated _i.c.
+ */
+typedef struct Handler {
+    const void *lpVtbl;
+    volatile LONG rc;
+    JSaddleWV2 *app;
+} Handler;
+
+static HRESULT STDMETHODCALLTYPE h_QueryInterface(void *self, REFIID riid, void **ppv)
+{
+    (void)riid;
+    if (!ppv) return E_POINTER;
+    *ppv = self;
+    InterlockedIncrement(&((Handler *)self)->rc);
+    return S_OK;
+}
+
+static ULONG STDMETHODCALLTYPE h_AddRef(void *self)
+{
+    return (ULONG)InterlockedIncrement(&((Handler *)self)->rc);
+}
+
+static ULONG STDMETHODCALLTYPE h_Release(void *self)
+{
+    LONG rc = InterlockedDecrement(&((Handler *)self)->rc);
+    if (rc == 0) free(self);
+    return (ULONG)rc;
+}
+
+#define IMPL_UNKNOWN(TYPE) \
+    (HRESULT (STDMETHODCALLTYPE *)(TYPE *, REFIID, void **))h_QueryInterface, \
+    (ULONG (STDMETHODCALLTYPE *)(TYPE *))h_AddRef, \
+    (ULONG (STDMETHODCALLTYPE *)(TYPE *))h_Release
+
+static Handler *newHandler(const void *vtbl, JSaddleWV2 *app)
+{
+    Handler *h = (Handler *)calloc(1, sizeof *h);
+    if (!h) return NULL;
+    h->lpVtbl = vtbl;
+    h->rc = 1;
+    h->app = app;
+    return h;
+}
+
+/* -------------------------------------------- no-op completed handler
+ * Shared by AddScriptToExecuteOnDocumentCreated and ExecuteScript -- both
+ * Invoke signatures are (HRESULT, LPCWSTR).
+ */
+static HRESULT STDMETHODCALLTYPE noop_Invoke(
+    ICoreWebView2ExecuteScriptCompletedHandler *self, HRESULT hr, LPCWSTR result)
+{
+    (void)self; (void)hr; (void)result;
+    return S_OK;
+}
+
+static const ICoreWebView2ExecuteScriptCompletedHandlerVtbl noopVtbl = {
+    IMPL_UNKNOWN(ICoreWebView2ExecuteScriptCompletedHandler),
+    noop_Invoke
+};
+
+/* --------------------------------------------------- event callbacks */
+
+static HRESULT STDMETHODCALLTYPE navCompleted_Invoke(
+    ICoreWebView2NavigationCompletedEventHandler *self,
+    ICoreWebView2 *sender, ICoreWebView2NavigationCompletedEventArgs *args)
+{
+    (void)sender; (void)args;
+    JSaddleWV2 *app = ((Handler *)self)->app;
+    /* jsaddle state does not survive a reload, so only signal the first
+       completed navigation (a second putMVar would block the UI thread). */
+    if (app->handlersSet && !app->started) {
+        app->started = 1;
+        jsaddleStart(app->startHandler);
+    }
+    return S_OK;
+}
+
+static const ICoreWebView2NavigationCompletedEventHandlerVtbl navCompletedVtbl = {
+    IMPL_UNKNOWN(ICoreWebView2NavigationCompletedEventHandler),
+    navCompleted_Invoke
+};
+
+static HRESULT STDMETHODCALLTYPE webMessage_Invoke(
+    ICoreWebView2WebMessageReceivedEventHandler *self,
+    ICoreWebView2 *sender, ICoreWebView2WebMessageReceivedEventArgs *args)
+{
+    (void)sender;
+    JSaddleWV2 *app = ((Handler *)self)->app;
+    LPWSTR msg = NULL;
+    if (app->handlersSet
+        && SUCCEEDED(ICoreWebView2WebMessageReceivedEventArgs_TryGetWebMessageAsString(args, &msg))
+        && msg) {
+        char *u = utf8FromWide(msg);
+        if (u) {
+            jsaddleResult(app->resultHandler, u);
+            free(u);
+        }
+    }
+    if (msg) CoTaskMemFree(msg);
+    return S_OK;
+}
+
+static const ICoreWebView2WebMessageReceivedEventHandlerVtbl webMessageVtbl = {
+    IMPL_UNKNOWN(ICoreWebView2WebMessageReceivedEventHandler),
+    webMessage_Invoke
+};
+
+static HRESULT STDMETHODCALLTYPE scriptDialog_Invoke(
+    ICoreWebView2ScriptDialogOpeningEventHandler *self,
+    ICoreWebView2 *sender, ICoreWebView2ScriptDialogOpeningEventArgs *args)
+{
+    (void)sender;
+    JSaddleWV2 *app = ((Handler *)self)->app;
+    COREWEBVIEW2_SCRIPT_DIALOG_KIND kind;
+    if (FAILED(ICoreWebView2ScriptDialogOpeningEventArgs_get_Kind(args, &kind))
+        || kind != COREWEBVIEW2_SCRIPT_DIALOG_KIND_PROMPT)
+        return S_OK;
+
+    LPWSTR message = NULL;
+    ICoreWebView2ScriptDialogOpeningEventArgs_get_Message(args, &message);
+    int isSync = message && wcscmp(message, L"JSaddleSync") == 0;
+    if (message) CoTaskMemFree(message);
+    if (!isSync || !app->handlersSet)
+        return S_OK; /* not ours: leave unaccepted, prompt() returns null */
+
+    LPWSTR defText = NULL;
+    ICoreWebView2ScriptDialogOpeningEventArgs_get_DefaultText(args, &defText);
+    char *u = utf8FromWide(defText);
+    if (defText) CoTaskMemFree(defText);
+    if (!u) return S_OK;
+
+    free(app->syncResult);
+    app->syncResult = NULL;
+    /* Synchronous round trip into Haskell: computes the reply Batch and
+       stores it via completeSyncWV2 before returning. */
+    jsaddleSyncResult(app->syncHandler, app, u);
+    free(u);
+
+    if (app->syncResult) {
+        LPWSTR w = wideFromUtf8(app->syncResult);
+        if (w) {
+            ICoreWebView2ScriptDialogOpeningEventArgs_put_ResultText(args, w);
+            ICoreWebView2ScriptDialogOpeningEventArgs_Accept(args);
+            free(w);
+        }
+        free(app->syncResult);
+        app->syncResult = NULL;
+    }
+    return S_OK;
+}
+
+static const ICoreWebView2ScriptDialogOpeningEventHandlerVtbl scriptDialogVtbl = {
+    IMPL_UNKNOWN(ICoreWebView2ScriptDialogOpeningEventHandler),
+    scriptDialog_Invoke
+};
+
+/* -------------------------------------------- controller / environment */
+
+static HRESULT STDMETHODCALLTYPE controllerCompleted_Invoke(
+    ICoreWebView2CreateCoreWebView2ControllerCompletedHandler *self,
+    HRESULT hr, ICoreWebView2Controller *controller)
+{
+    JSaddleWV2 *app = ((Handler *)self)->app;
+    if (FAILED(hr) || !controller) {
+        fprintf(stderr, "jsaddle-webview2: controller creation failed (0x%08lx)\n",
+                (unsigned long)hr);
+        PostQuitMessage(1);
+        return hr;
+    }
+
+    app->controller = controller;
+    ICoreWebView2Controller_AddRef(controller);
+    ICoreWebView2Controller_get_CoreWebView2(controller, &app->webview);
+
+    ICoreWebView2Settings *settings = NULL;
+    ICoreWebView2_get_Settings(app->webview, &settings);
+    if (settings) {
+        ICoreWebView2Settings_put_IsScriptEnabled(settings, TRUE);
+        ICoreWebView2Settings_put_IsWebMessageEnabled(settings, TRUE);
+        /* Required for the JSaddleSync prompt() intercept. */
+        ICoreWebView2Settings_put_AreDefaultScriptDialogsEnabled(settings, FALSE);
+        ICoreWebView2Settings_put_AreDevToolsEnabled(settings, app->devTools ? TRUE : FALSE);
+        ICoreWebView2Settings_Release(settings);
+    }
+
+    EventRegistrationToken tok;
+    Handler *h;
+
+    h = newHandler(&navCompletedVtbl, app);
+    ICoreWebView2_add_NavigationCompleted(app->webview,
+        (ICoreWebView2NavigationCompletedEventHandler *)h, &tok);
+    h_Release(h);
+
+    h = newHandler(&webMessageVtbl, app);
+    ICoreWebView2_add_WebMessageReceived(app->webview,
+        (ICoreWebView2WebMessageReceivedEventHandler *)h, &tok);
+    h_Release(h);
+
+    h = newHandler(&scriptDialogVtbl, app);
+    ICoreWebView2_add_ScriptDialogOpening(app->webview,
+        (ICoreWebView2ScriptDialogOpeningEventHandler *)h, &tok);
+    h_Release(h);
+
+    RECT rc;
+    GetClientRect(app->hwnd, &rc);
+    ICoreWebView2Controller_put_Bounds(app->controller, rc);
+    ICoreWebView2Controller_put_IsVisible(app->controller, TRUE);
+
+    /* Hand control to Haskell: it wires the jsaddle handlers (wv2SetHandlers)
+       and starts the initial navigation. */
+    callWithWebView2(app, app->mainCallback);
+    return S_OK;
+}
+
+static const ICoreWebView2CreateCoreWebView2ControllerCompletedHandlerVtbl controllerCompletedVtbl = {
+    IMPL_UNKNOWN(ICoreWebView2CreateCoreWebView2ControllerCompletedHandler),
+    controllerCompleted_Invoke
+};
+
+static HRESULT STDMETHODCALLTYPE envCompleted_Invoke(
+    ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler *self,
+    HRESULT hr, ICoreWebView2Environment *env)
+{
+    JSaddleWV2 *app = ((Handler *)self)->app;
+    if (FAILED(hr) || !env) {
+        fprintf(stderr,
+            "jsaddle-webview2: environment creation failed (0x%08lx); is the WebView2 runtime installed?\n",
+            (unsigned long)hr);
+        PostQuitMessage(1);
+        return hr;
+    }
+    Handler *cc = newHandler(&controllerCompletedVtbl, app);
+    HRESULT r = ICoreWebView2Environment_CreateCoreWebView2Controller(env, app->hwnd,
+        (ICoreWebView2CreateCoreWebView2ControllerCompletedHandler *)cc);
+    h_Release(cc);
+    if (FAILED(r)) {
+        fprintf(stderr, "jsaddle-webview2: CreateCoreWebView2Controller failed (0x%08lx)\n",
+                (unsigned long)r);
+        PostQuitMessage(1);
+    }
+    return r;
+}
+
+static const ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandlerVtbl envCompletedVtbl = {
+    IMPL_UNKNOWN(ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler),
+    envCompleted_Invoke
+};
+
+/* ------------------------------------------------------- window proc */
+
+static LRESULT CALLBACK wndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp)
+{
+    JSaddleWV2 *app = (JSaddleWV2 *)GetWindowLongPtrW(hwnd, GWLP_USERDATA);
+    switch (msg) {
+    case WM_SIZE:
+        if (app && app->controller) {
+            RECT rc;
+            GetClientRect(hwnd, &rc);
+            ICoreWebView2Controller_put_Bounds(app->controller, rc);
+        }
+        return 0;
+    case WM_MOVE:
+        if (app && app->controller)
+            ICoreWebView2Controller_NotifyParentWindowPositionChanged(app->controller);
+        return 0;
+    case WM_JSADDLE_EVAL:
+        if (app && app->webview) {
+            Handler *h = newHandler(&noopVtbl, app);
+            ICoreWebView2_ExecuteScript(app->webview, (LPCWSTR)lp,
+                (ICoreWebView2ExecuteScriptCompletedHandler *)h);
+            h_Release(h);
+        }
+        free((void *)lp);
+        return 0;
+    case WM_JSADDLE_NAV_URL:
+        if (app && app->webview)
+            ICoreWebView2_Navigate(app->webview, (LPCWSTR)lp);
+        free((void *)lp);
+        return 0;
+    case WM_JSADDLE_NAV_HTML:
+        if (app && app->webview)
+            ICoreWebView2_NavigateToString(app->webview, (LPCWSTR)lp);
+        free((void *)lp);
+        return 0;
+    case WM_DESTROY:
+        PostQuitMessage(0);
+        return 0;
+    }
+    return DefWindowProcW(hwnd, msg, wp, lp);
+}
+
+/* ------------------------------------------- API called from Haskell */
+
+void wv2SetHandlers(JSaddleWV2 *app, HsStablePtr start, HsStablePtr result, HsStablePtr sync)
+{
+    app->startHandler = start;
+    app->resultHandler = result;
+    app->syncHandler = sync;
+    app->handlersSet = 1;
+}
+
+/* Thread-safe: marshalled to the UI thread via PostMessage. */
+void wv2Eval(JSaddleWV2 *app, const char *js)
+{
+    LPWSTR w = wideFromUtf8(js);
+    if (w && !PostMessageW(app->hwnd, WM_JSADDLE_EVAL, 0, (LPARAM)w))
+        free(w);
+}
+
+void wv2Navigate(JSaddleWV2 *app, const char *url)
+{
+    LPWSTR w = wideFromUtf8(url);
+    if (w && !PostMessageW(app->hwnd, WM_JSADDLE_NAV_URL, 0, (LPARAM)w))
+        free(w);
+}
+
+void wv2NavigateToString(JSaddleWV2 *app, const char *html)
+{
+    LPWSTR w = wideFromUtf8(html);
+    if (w && !PostMessageW(app->hwnd, WM_JSADDLE_NAV_HTML, 0, (LPARAM)w))
+        free(w);
+}
+
+/* Called by Haskell inside jsaddleSyncResult (same thread, same dynamic
+   extent) with the reply Batch JSON for the pending JSaddleSync prompt. */
+void completeSyncWV2(JSaddleWV2 *app, const char *s)
+{
+    free(app->syncResult);
+    app->syncResult = s ? strdup(s) : NULL;
+}
+
+typedef HRESULT (STDMETHODCALLTYPE *CreateEnvFn)(
+    PCWSTR, PCWSTR, ICoreWebView2EnvironmentOptions *,
+    ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler *);
+
+int runJsaddleWebView2(HsStablePtr mainCallback, const char *title,
+                       int width, int height, int devTools)
+{
+    /* Per-monitor v2 DPI awareness, where available (Win10 1703+). */
+    HMODULE user32 = GetModuleHandleW(L"user32.dll");
+    if (user32) {
+        typedef BOOL (WINAPI *SetDpiCtxFn)(HANDLE);
+        SetDpiCtxFn setCtx = (SetDpiCtxFn)(void *)GetProcAddress(user32, "SetProcessDpiAwarenessContext");
+        if (setCtx) setCtx((HANDLE)-4 /* DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 */);
+    }
+
+    HMODULE loader = LoadLibraryW(L"WebView2Loader.dll");
+    if (!loader) {
+        fprintf(stderr, "jsaddle-webview2: WebView2Loader.dll not found; place it next to the executable\n");
+        return 1;
+    }
+    CreateEnvFn createEnv = (CreateEnvFn)(void *)GetProcAddress(loader, "CreateCoreWebView2EnvironmentWithOptions");
+    if (!createEnv) {
+        fprintf(stderr, "jsaddle-webview2: CreateCoreWebView2EnvironmentWithOptions not found in WebView2Loader.dll\n");
+        return 1;
+    }
+
+    HRESULT hr = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
+    if (FAILED(hr)) {
+        fprintf(stderr, "jsaddle-webview2: CoInitializeEx failed (0x%08lx)\n", (unsigned long)hr);
+        return 1;
+    }
+
+    JSaddleWV2 *app = (JSaddleWV2 *)calloc(1, sizeof *app);
+    app->mainCallback = mainCallback;
+    app->devTools = devTools;
+
+    WNDCLASSW wc;
+    memset(&wc, 0, sizeof wc);
+    wc.lpfnWndProc = wndProc;
+    wc.hInstance = GetModuleHandleW(NULL);
+    wc.lpszClassName = L"JSaddleWebView2";
+    wc.hCursor = LoadCursorW(NULL, MAKEINTRESOURCEW(32512) /* IDC_ARROW */);
+    wc.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
+    RegisterClassW(&wc);
+
+    LPWSTR wtitle = wideFromUtf8(title);
+    app->hwnd = CreateWindowExW(0, wc.lpszClassName, wtitle ? wtitle : L"JSaddle",
+        WS_OVERLAPPEDWINDOW, CW_USEDEFAULT, CW_USEDEFAULT,
+        width > 0 ? width : CW_USEDEFAULT, height > 0 ? height : CW_USEDEFAULT,
+        NULL, NULL, wc.hInstance, NULL);
+    free(wtitle);
+    if (!app->hwnd) {
+        fprintf(stderr, "jsaddle-webview2: CreateWindow failed\n");
+        return 1;
+    }
+    SetWindowLongPtrW(app->hwnd, GWLP_USERDATA, (LONG_PTR)app);
+    ShowWindow(app->hwnd, SW_SHOWDEFAULT);
+    UpdateWindow(app->hwnd);
+
+    /* Default user-data folder is next to the exe, which fails under
+       Program Files; use %LOCALAPPDATA%\jsaddle-webview2 instead. */
+    WCHAR udf[MAX_PATH];
+    PCWSTR udfArg = NULL;
+    DWORD n = GetEnvironmentVariableW(L"LOCALAPPDATA", udf, MAX_PATH);
+    if (n > 0 && n + 20 < MAX_PATH) {
+        wcscat(udf, L"\\jsaddle-webview2");
+        CreateDirectoryW(udf, NULL);
+        udfArg = udf;
+    }
+
+    Handler *envH = newHandler(&envCompletedVtbl, app);
+    hr = createEnv(NULL, udfArg, NULL,
+        (ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler *)envH);
+    h_Release(envH);
+    if (FAILED(hr)) {
+        fprintf(stderr,
+            "jsaddle-webview2: CreateCoreWebView2EnvironmentWithOptions failed (0x%08lx); is the WebView2 runtime installed?\n",
+            (unsigned long)hr);
+        return 1;
+    }
+
+    MSG msg;
+    while (GetMessageW(&msg, NULL, 0, 0) > 0) {
+        TranslateMessage(&msg);
+        DispatchMessageW(&msg);
+    }
+    return (int)msg.wParam;
+}

--- a/jsaddle-webview2/demo/Main.hs
+++ b/jsaddle-webview2/demo/Main.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ExtendedDefaultRules #-}
+{-# OPTIONS_GHC -Wno-type-defaults #-}
+-- | Minimal jsaddle-webview2 demo: a click counter (exercises the
+--   synchronous prompt bridge via the callback) and an uptime ticker
+--   (exercises async batches from a background Haskell thread).
+module Main (main) where
+
+import Control.Concurrent (forkIO, threadDelay)
+import Control.Monad (forever, void)
+import Control.Monad.IO.Class (liftIO)
+import Data.IORef (atomicModifyIORef', newIORef)
+import qualified Data.Text as T
+import Language.Javascript.JSaddle
+import qualified Language.Javascript.JSaddle.WebView2 as WV2
+
+main :: IO ()
+main = WV2.run $ do
+    doc <- jsg "document"
+    body <- doc ! "body"
+    void $ body # "insertAdjacentHTML" $
+        ( "beforeend"
+        , "<h1>jsaddle-webview2 demo</h1>\
+          \<p>Uptime: <span id=\"uptime\">0</span>s</p>\
+          \<p><button id=\"btn\">Clicked <span id=\"count\">0</span> times</button></p>"
+        )
+
+    clicks <- liftIO $ newIORef (0 :: Int)
+    btn <- doc # "getElementById" $ ["btn"]
+    void $ btn # "addEventListener" $
+        ( "click"
+        , fun $ \_ _ _ -> do
+            n <- liftIO $ atomicModifyIORef' clicks $ \c -> (c + 1, c + 1)
+            el <- doc # "getElementById" $ ["count"]
+            el <# "textContent" $ T.pack (show n)
+        )
+
+    seconds <- liftIO $ newIORef (0 :: Int)
+    ctx <- askJSM
+    void . liftIO . forkIO . forever $ do
+        threadDelay 1000000
+        s <- atomicModifyIORef' seconds $ \c -> (c + 1, c + 1)
+        runJSaddle ctx $ do
+            el <- jsg "document" # "getElementById" $ ["uptime"]
+            el <# "textContent" $ T.pack (show s)

--- a/jsaddle-webview2/jsaddle-webview2.cabal
+++ b/jsaddle-webview2/jsaddle-webview2.cabal
@@ -9,7 +9,7 @@ synopsis: Interface for JavaScript that works with GHCJS and GHC
 description:
     jsaddle backend for Windows: hosts the app in a native Win32 window
     containing a Microsoft Edge WebView2 control.  The Windows sibling of
-    jsaddle-wkwebview (macOS/iOS) and jsaddle-webkit2gtk (Linux).
+    jsaddle-wkwebview (macOS/iOS) and jsaddle-webkitgtk (Linux).
     .
     Building needs WebView2.h from the Microsoft.Web.WebView2 NuGet package
     on the include path (see the README); nothing from the SDK is needed at

--- a/jsaddle-webview2/jsaddle-webview2.cabal
+++ b/jsaddle-webview2/jsaddle-webview2.cabal
@@ -1,0 +1,55 @@
+cabal-version: 3.0
+name: jsaddle-webview2
+version: 0.1.0.0
+build-type: Simple
+license: MIT
+license-file: LICENSE
+maintainer: Hamish Mackenzie <Hamish.K.Mackenzie@googlemail.com>
+synopsis: Interface for JavaScript that works with GHCJS and GHC
+description:
+    jsaddle backend for Windows: hosts the app in a native Win32 window
+    containing a Microsoft Edge WebView2 control.  The Windows sibling of
+    jsaddle-wkwebview (macOS/iOS) and jsaddle-webkit2gtk (Linux).
+    .
+    Building needs WebView2.h from the Microsoft.Web.WebView2 NuGet package
+    on the include path (see the README); nothing from the SDK is needed at
+    link time.  Running needs the WebView2 runtime (preinstalled on Windows
+    11) and WebView2Loader.dll next to the executable.
+category: Web, Javascript
+author: Hamish Mackenzie
+
+source-repository head
+    type: git
+    location: https://github.com/ghcjs/jsaddle
+
+library
+    exposed-modules:
+        Language.Javascript.JSaddle.WebView2
+        Language.Javascript.JSaddle.WebView2.Internal
+    hs-source-dirs: src
+    default-language: Haskell2010
+    ghc-options: -ferror-spans -Wall
+    build-depends:
+        base <5,
+        aeson >=0.8.0.2 && <2.3,
+        bytestring >=0.10.6.0 && <0.13,
+        data-default,
+        jsaddle >=0.9.9.0 && <0.10,
+        text
+    c-sources: cbits/WebView2Shim.c
+    extra-libraries: ole32, user32
+    if !os(windows)
+        buildable: False
+
+executable jsaddle-webview2-demo
+    main-is: Main.hs
+    hs-source-dirs: demo
+    default-language: Haskell2010
+    ghc-options: -threaded -Wall
+    build-depends:
+        base,
+        jsaddle,
+        jsaddle-webview2,
+        text
+    if !os(windows)
+        buildable: False

--- a/jsaddle-webview2/src/Language/Javascript/JSaddle/WebView2.hs
+++ b/jsaddle-webview2/src/Language/Javascript/JSaddle/WebView2.hs
@@ -1,0 +1,95 @@
+{-# LANGUAGE ForeignFunctionInterface, OverloadedStrings #-}
+-- | Run jsaddle apps in a native Windows window hosting a Microsoft Edge
+--   WebView2 control.  The Windows sibling of
+--   "Language.Javascript.JSaddle.WKWebView" (macOS\/iOS) and
+--   "Language.Javascript.JSaddle.WebKitGTK" (Linux).
+--
+--   Requirements on the target machine:
+--
+--   * the WebView2 runtime (preinstalled on Windows 11; Evergreen-installed
+--     on most Windows 10 machines, or bundle the installer), and
+--
+--   * @WebView2Loader.dll@ from the WebView2 SDK NuGet package
+--     (@Microsoft.Web.WebView2@, @runtimes\/win-x64\/native@) next to the
+--     executable.  It is loaded dynamically, so nothing from the SDK is
+--     needed at link time.
+module Language.Javascript.JSaddle.WebView2
+    ( run
+    , runHTML
+    , runURL
+    , run'
+    , WebView2Config(..)
+    , WebView2(..)
+    ) where
+
+import Control.Monad (unless)
+import Data.ByteString (ByteString, useAsCString)
+import Data.Default (Default(..))
+import Data.Text (Text)
+import qualified Data.Text as T (pack)
+import Data.Text.Encoding (encodeUtf8)
+
+import Foreign.C.String (CString)
+import Foreign.C.Types (CInt(..))
+import Foreign.StablePtr (StablePtr, newStablePtr)
+
+import Language.Javascript.JSaddle (JSM)
+import Language.Javascript.JSaddle.WebView2.Internal
+       (jsaddleMain, jsaddleMainHTML, jsaddleMainURL, WebView2(..))
+import System.Environment (getProgName)
+
+foreign import ccall runJsaddleWebView2
+    :: StablePtr (WebView2 -> IO ())
+    -> CString -- ^ window title (utf8)
+    -> CInt    -- ^ initial width  (<=0 for default)
+    -> CInt    -- ^ initial height (<=0 for default)
+    -> CInt    -- ^ enable dev tools
+    -> IO CInt
+
+data WebView2Config = WebView2Config
+    { _webView2Config_title :: Maybe Text
+    -- ^ Window title; 'Nothing' uses the program name.
+    , _webView2Config_width :: Int
+    -- ^ Initial window width; @<= 0@ for the system default.
+    , _webView2Config_height :: Int
+    -- ^ Initial window height; @<= 0@ for the system default.
+    , _webView2Config_devTools :: Bool
+    -- ^ Allow opening the Edge dev tools (F12).  Defaults to 'True'.
+    }
+
+instance Default WebView2Config where
+    def = WebView2Config
+        { _webView2Config_title = Nothing
+        , _webView2Config_width = 0
+        , _webView2Config_height = 0
+        , _webView2Config_devTools = True
+        }
+
+-- | Run a jsaddle app in a WebView2 window (blank initial page).
+run :: JSM () -> IO ()
+run f = run' def (jsaddleMain f)
+
+-- | Run a jsaddle app in a WebView2 window, starting from the given HTML
+--   (loaded with @NavigateToString@: origin @about:blank@, 2MB limit).
+runHTML :: ByteString -> WebView2Config -> JSM () -> IO ()
+runHTML html cfg = run' cfg . jsaddleMainHTML html
+
+-- | Run a jsaddle app in a WebView2 window, first navigating to the given
+--   URL (@file:\/\/@, @https:\/\/@, ...).
+runURL :: ByteString -> WebView2Config -> JSM () -> IO ()
+runURL url cfg = run' cfg . jsaddleMainURL url
+
+-- | Run an action with the WebView2 once its controller is ready.  This is
+--   the escape hatch mirroring 'Language.Javascript.JSaddle.WKWebView.run'':
+--   the callback runs on the UI thread before any navigation has started.
+run' :: WebView2Config -> (WebView2 -> IO ()) -> IO ()
+run' cfg main = do
+    title <- maybe (T.pack <$> getProgName) pure (_webView2Config_title cfg)
+    mainPtr <- newStablePtr main
+    r <- useAsCString (encodeUtf8 title) $ \t ->
+        runJsaddleWebView2 mainPtr t
+            (fromIntegral $ _webView2Config_width cfg)
+            (fromIntegral $ _webView2Config_height cfg)
+            (if _webView2Config_devTools cfg then 1 else 0)
+    unless (r == 0) . ioError . userError $
+        "jsaddle-webview2 failed to start (is the WebView2 runtime installed and WebView2Loader.dll next to the executable?)"

--- a/jsaddle-webview2/src/Language/Javascript/JSaddle/WebView2/Internal.hs
+++ b/jsaddle-webview2/src/Language/Javascript/JSaddle/WebView2/Internal.hs
@@ -1,0 +1,132 @@
+{-# LANGUAGE ForeignFunctionInterface, OverloadedStrings #-}
+-- | Wiring between jsaddle's 'runJavaScript' transport and the WebView2
+--   C shim (@cbits/WebView2Shim.c@).  Mirrors
+--   "Language.Javascript.JSaddle.WKWebView.Internal".
+module Language.Javascript.JSaddle.WebView2.Internal
+    ( jsaddleMain
+    , jsaddleMainHTML
+    , jsaddleMainURL
+    , WebView2(..)
+    ) where
+
+import Control.Monad (void, join)
+import Control.Concurrent (forkIO, forkOS)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+
+import Data.ByteString (useAsCString)
+import qualified Data.ByteString as BS (ByteString, packCString)
+import Data.ByteString.Lazy (ByteString, toStrict, fromStrict)
+import Data.Aeson (encode, decode)
+
+import Foreign.C.String (CString)
+import Foreign.Ptr (Ptr)
+import Foreign.StablePtr (StablePtr, newStablePtr, deRefStablePtr)
+
+import Language.Javascript.JSaddle (Results, Batch, JSM)
+import Language.Javascript.JSaddle.Run (runJavaScript)
+import Language.Javascript.JSaddle.Run.Files (initState, runBatch, ghcjsHelpers)
+
+newtype WebView2 = WebView2 (Ptr WebView2)
+
+foreign export ccall jsaddleStart :: StablePtr (IO ()) -> IO ()
+foreign export ccall jsaddleResult :: StablePtr (Results -> IO ()) -> CString -> IO ()
+foreign export ccall jsaddleSyncResult :: StablePtr (Results -> IO Batch) -> WebView2 -> CString -> IO ()
+foreign export ccall callWithWebView2 :: WebView2 -> StablePtr (WebView2 -> IO ()) -> IO ()
+
+foreign import ccall wv2SetHandlers
+    :: WebView2 -> StablePtr (IO ()) -> StablePtr (Results -> IO ()) -> StablePtr (Results -> IO Batch) -> IO ()
+foreign import ccall wv2Eval :: WebView2 -> CString -> IO ()
+foreign import ccall wv2Navigate :: WebView2 -> CString -> IO ()
+foreign import ccall wv2NavigateToString :: WebView2 -> CString -> IO ()
+foreign import ccall completeSyncWV2 :: WebView2 -> CString -> IO ()
+
+-- | Run a jsaddle app in the WebView2, starting from a minimal blank page.
+jsaddleMain :: JSM () -> WebView2 -> IO ()
+jsaddleMain = jsaddleMainHTML (toStrict indexHtml)
+
+-- | Run a jsaddle app in the WebView2, starting from the given HTML
+--   (loaded with @NavigateToString@, so the page origin is @about:blank@
+--   and the content is limited to 2MB).
+jsaddleMainHTML :: BS.ByteString -> JSM () -> WebView2 -> IO ()
+jsaddleMainHTML html f webView =
+    jsaddleMain' f webView $
+        useAsCString html $ wv2NavigateToString webView
+
+-- | Run a jsaddle app in the WebView2, first navigating to the given URL
+--   (@file://@, @https://@, ...).
+jsaddleMainURL :: BS.ByteString -> JSM () -> WebView2 -> IO ()
+jsaddleMainURL url f webView =
+    jsaddleMain' f webView $
+        useAsCString url $ wv2Navigate webView
+
+jsaddleMain' :: JSM () -> WebView2 -> IO () -> IO ()
+jsaddleMain' f webView navigate = do
+    ready <- newEmptyMVar
+
+    (processResult, syncResult, start) <- runJavaScript (\batch ->
+        useAsCString (toStrict $ "runJSaddleBatch(" <> encode batch <> ");") $
+            wv2Eval webView)
+        f
+
+    startHandler <- newStablePtr (putMVar ready ())
+    resultHandler <- newStablePtr processResult
+    syncResultHandler <- newStablePtr syncResult
+    wv2SetHandlers webView startHandler resultHandler syncResultHandler
+    navigate
+    void . forkOS $ do
+        takeMVar ready
+        useAsCString (toStrict jsaddleJs) (wv2Eval webView) >> void (forkIO start)
+
+jsaddleStart :: StablePtr (IO ()) -> IO ()
+jsaddleStart ptrHandler = join (deRefStablePtr ptrHandler)
+
+jsaddleResult :: StablePtr (Results -> IO ()) -> CString -> IO ()
+jsaddleResult ptrHandler s = do
+    processResult <- deRefStablePtr ptrHandler
+    result <- BS.packCString s
+    case decode (fromStrict result) of
+        Nothing -> error $ "jsaddle Results decode failed : " <> show result
+        Just r  -> processResult r
+
+-- | Called from the ScriptDialogOpening handler while the page's JS is
+--   blocked in @window.prompt("JSaddleSync", ...)@.  The reply Batch must be
+--   handed back with 'completeSyncWV2' before this returns (the C side reads
+--   it right after).
+jsaddleSyncResult :: StablePtr (Results -> IO Batch) -> WebView2 -> CString -> IO ()
+jsaddleSyncResult ptrHandler webView s = do
+    syncProcessResult <- deRefStablePtr ptrHandler
+    result <- BS.packCString s
+    case decode (fromStrict result) of
+        Nothing -> error $ "jsaddle Results decode failed : " <> show result
+        Just r  -> do
+            batch <- syncProcessResult r
+            useAsCString (toStrict $ encode batch) $
+                completeSyncWV2 webView
+
+callWithWebView2 :: WebView2 -> StablePtr (WebView2 -> IO ()) -> IO ()
+callWithWebView2 webView ptrF = do
+    f <- deRefStablePtr ptrF
+    f webView
+
+jsaddleJs :: ByteString
+jsaddleJs = ghcjsHelpers <> "\
+    \runJSaddleBatch = (function() {\n\
+    \ " <> initState <> "\n\
+    \ return function(batch) {\n\
+    \ " <> runBatch (\a -> "window.chrome.webview.postMessage(JSON.stringify(" <> a <> "));\n")
+                    (Just (\a -> "JSON.parse(window.prompt(\"JSaddleSync\", JSON.stringify(" <> a <> ")))")) <> "\
+    \ };\n\
+    \})();\n\
+    \"
+
+indexHtml :: ByteString
+indexHtml =
+    "<!DOCTYPE html>\n\
+    \<html>\n\
+    \<head>\n\
+    \<meta charset=\"utf-8\">\n\
+    \<title>JSaddle</title>\n\
+    \</head>\n\
+    \<body>\n\
+    \</body>\n\
+    \</html>"

--- a/jsaddle-wkwebview/jsaddle-wkwebview.cabal
+++ b/jsaddle-wkwebview/jsaddle-wkwebview.cabal
@@ -31,7 +31,9 @@ library
     default-language: Haskell2010
     hs-source-dirs: src
     ghc-options: -ferror-spans -Wall
-    if os(linux)
+    -- Native builds need the Foundation/WebKit frameworks: macOS and iOS
+    -- only.  (The ghcjs/javascript branch below builds anywhere.)
+    if !os(osx) && !os(ios) && !impl(ghcjs) && !arch(javascript)
         buildable: False
     if impl(ghcjs) || arch(javascript)
         hs-source-dirs: src-ghcjs

--- a/nix/hix.nix
+++ b/nix/hix.nix
@@ -1,10 +1,23 @@
 {config, pkgs, ...}: {
-  compiler-nix-name = "ghc912";
+  compiler-nix-name = "ghc914";
   flake.variants.ghc96.compiler-nix-name = pkgs.lib.mkForce "ghc96";
-  modules = [({pkgs, ...}: {
-    package-keys = ["webkit2gtk3-javascriptcore"];
+  modules = [({pkgs, lib, ...}: let
+    # WebView2.h for jsaddle-webview2's C shim.  Only the header is needed
+    # (WebView2Loader.dll is loaded dynamically at run time), so nothing
+    # from the SDK is linked into the build.
+    webview2-sdk = pkgs.pkgsBuildBuild.fetchzip {
+      url = "https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/1.0.4022.49";
+      extension = "zip";
+      stripRoot = false;
+      hash = "sha256-RoVh4A/Pg9/40kHtIIsC916QgPkB8TnDeOvN4ptPNM4=";
+    };
+  in {
+    package-keys = ["webkit2gtk3-javascriptcore" "jsaddle-webview2"];
     packages.webkit2gtk3-javascriptcore.components.library.doHaddock = false;
     enableStatic = !pkgs.stdenv.hostPlatform.isGhcjs;
+    packages.jsaddle-webview2.components.library.configureFlags =
+      lib.optionals pkgs.stdenv.hostPlatform.isWindows
+        [ "--extra-include-dirs=${webview2-sdk}/build/native/include" ];
   })];
   shell.buildInputs = [ pkgs.pkgsBuildBuild.nodejs ];
   shell.tools.cabal = {};
@@ -12,7 +25,7 @@
   shell.tools.haskell-ci.cabalProjectLocal = ''
     allow-newer: *:base
   '';
-  crossPlatforms = p: [ p.ghcjs ];
+  crossPlatforms = p: [ p.ghcjs p.ucrt64 ];
 
   # Use this for checking if `aeson` 2 works (tests will not build because `webdriver` still needs aeson <2)
   cabalProjectLocal = ''

--- a/nix/webkitgtk-smoke.nix
+++ b/nix/webkitgtk-smoke.nix
@@ -1,0 +1,37 @@
+# Headless runtime smoke test for jsaddle-webkitgtk: runs the demo's
+# --smoke mode (async eval round trip + a JS→Haskell callback through the
+# synchronous JSaddleSync script-dialog path) under Xvfb and asserts it
+# prints SMOKE-OK.
+#
+# The environment exists to make WebKitGTK viable inside the nix build
+# sandbox: no /etc/dbus-1 (point dbus at its store config), no bubblewrap
+# (WebKit's own sandbox can't nest), and no /run/opengl-driver (point
+# glvnd/mesa loaders at the store and software-render with llvmpipe).
+{ lib, runCommand, xvfb-run, dbus, gsettings-desktop-schemas, gtk4, mesa
+, jsaddle-webkitgtk-demo }:
+let
+  mesaDrivers = mesa.drivers or mesa;
+in
+runCommand "jsaddle-webkitgtk-smoke" {
+  nativeBuildInputs = [ xvfb-run dbus jsaddle-webkitgtk-demo ];
+} ''
+  export HOME=$TMPDIR
+  export XDG_RUNTIME_DIR=$TMPDIR
+  export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk4}/share/gsettings-schemas/${gtk4.name}:''${XDG_DATA_DIRS:-}
+  export WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
+  export WEBKIT_DISABLE_DMABUF_RENDERER=1
+  export WEBKIT_DISABLE_COMPOSITING_MODE=1
+  export GDK_BACKEND=x11
+  export GTK_A11Y=none
+  export GSK_RENDERER=cairo
+  export LIBGL_ALWAYS_SOFTWARE=1
+  export GALLIUM_DRIVER=llvmpipe
+  export __EGL_VENDOR_LIBRARY_DIRS=${mesaDrivers}/share/glvnd/egl_vendor.d
+  export LIBGL_DRIVERS_PATH=${mesaDrivers}/lib/dri
+  export GBM_BACKENDS_PATH=${mesaDrivers}/lib/gbm
+  xvfb-run -a -s "-screen 0 1024x768x24" \
+    dbus-run-session --config-file=${dbus}/share/dbus-1/session.conf -- \
+    jsaddle-webkitgtk-demo --smoke 2>&1 | tee log || true
+  grep -q "SMOKE-OK" log
+  cp log $out
+''


### PR DESCRIPTION
## Summary

This PR adds a Windows backend, modernises the Linux backend, and makes the whole repo solve on every platform from one flat `cabal.project`.

- **New package `jsaddle-webview2`** — Windows backend hosting the app in a native Win32 window with a Microsoft Edge WebView2 control.
- **`jsaddle-webkitgtk` ported to GTK4 + WebKitGTK 6.0** — replaces the WebKit1/GTK3 code (and supersedes `jsaddle-webkit2gtk`, whose webkit2gtk-4.0 dependency no longer exists in nixpkgs).
- **`cabal.project` restructured** — flat unconditional `packages:` list with per-package `buildable: False` platform guards.
- **Flake: haskell.nix bump + headless runtime smoke test** for the WebKitGTK backend.

## jsaddle-webview2

Mirrors jsaddle-wkwebview's design: async batches are evaluated as `runJSaddleBatch(...)` and results come back via `chrome.webview.postMessage`; synchronous results use `window.prompt("JSaddleSync", …)` intercepted natively in `ScriptDialogOpening`.

The C shim (`cbits/WebView2Shim.c`) is plain-C COM against the official `WebView2.h` — only the header is needed at compile time (fetched from the WebView2 NuGet package in `nix/hix.nix` for cross builds); `WebView2Loader.dll` is loaded dynamically at run time and the WebView2 runtime ships with Windows 11. WebView2 is single-threaded (STA), so all `ICoreWebView2*` calls are marshalled to the UI thread via `PostMessage`.

Cross-compiles from nix via `hydraJobs.<system>.x86_64-w64-mingw32` (lib + demo exe verified). Not yet run on real Windows hardware — the prompt-bridge length limits and first-navigation timing are the known risks to check there.

## jsaddle-webkitgtk (GTK4 / WebKitGTK 6.0)

Rewritten against `gi-gtk4` / `gi-webkit` 6.x / `gi-javascriptcore6`: GLib main loop instead of `gtk_main`, `windowSetChild`/`scrolledWindowSetChild`, `webViewEvaluateJavascript`, and the WebKit 6 script-message + script-dialog (JSaddleSync prompt) bridge. Requires haskell.nix master (the WebKitGTK 6.0 pkg-config map entries — `webkitgtk-6.0`, `javascriptcoregtk-6.0` — landed there recently); the flake input is bumped accordingly.

A new demo executable has a `--smoke` mode that asserts a full bridge round trip (async eval, plus a JS→Haskell callback through the synchronous prompt path) and exits 0/1.

## Per-platform packaging

`cabal.project` `if os(...)` conditionals do **not** apply to `packages:` fields (silently ignored), so platform gating now lives in each `.cabal` file as `buildable: False` guards covering every component; the solver ignores dependencies of non-buildable components. Notes:

- `jsaddle-terminal`'s demo moved behind a manual `demo` flag (default off): reflex-dom-core caps `base` below new GHCs and otherwise makes the whole project unsolvable.
- `jsaddle-webkit2gtk` stays out of the project: a missing pkg-config package (webkit2gtk-4.0) fails the solve regardless of `buildable:` guards.

## CI / testing

- Plans verified for x86_64-linux, x86_64-w64-mingw32 cross, javascript-unknown-ghcjs cross, and aarch64-darwin — each contains exactly the intended components.
- New flake check `checks.<linux>.webkitgtk-smoke` (also in `hydraJobs.checks`) runs the WebKitGTK demo's `--smoke` mode headlessly under Xvfb inside the nix sandbox (dbus config from the store, WebKit's bubblewrap sandbox off, llvmpipe software EGL) and passes iff the bridge round-trips:

  ```
  SMOKE eval 6*7 = 42.0
  SMOKE callback got 123.0
  SMOKE-OK
  ```
