### PR TITLE
Windows/webkitgtk front-end support: build jsaddle-terminal on Windows, expose the WebView2 HWND

### DIFF
--- a/jsaddle-terminal/jsaddle-terminal.cabal
+++ b/jsaddle-terminal/jsaddle-terminal.cabal
@@ -31,23 +31,24 @@ library
   exposed-modules:    Language.Javascript.JSaddle.Terminal.Protocol
                       Language.Javascript.JSaddle.Terminal.Bootstrap
   build-depends:      base >=4.16 && <5
-                    , aeson
                     , base64-bytestring
                     , bytestring
                     , jsaddle >=0.9.4 && <0.10
-                    , jsaddle-warp >=0.9.4 && <0.10
-                    , stm
-                    , text
-                    , warp
-                    , websockets
   ghc-options:        -Wall
   default-language:   Haskell2010
   -- The tunnel runner needs raw-mode stdin/termios: POSIX only.  The framing
   -- (Protocol) and iframe JS (Bootstrap) are pure and build everywhere, so
-  -- IDE-side consumers (leksah) can link this library on Windows too.
+  -- IDE-side consumers (leksah) can link this library on Windows too —
+  -- without the runner's warp-fallback deps (jsaddle-warp caps aeson).
   if !os(windows)
     exposed-modules:  Language.Javascript.JSaddle.Terminal
-    build-depends:    unix
+    build-depends:      aeson
+                      , jsaddle-warp >=0.9.4 && <0.10
+                      , stm
+                      , text
+                      , unix
+                      , warp
+                      , websockets
 
 executable jsaddle-terminal-demo
   main-is:            Main.hs

--- a/jsaddle-terminal/jsaddle-terminal.cabal
+++ b/jsaddle-terminal/jsaddle-terminal.cabal
@@ -28,8 +28,7 @@ flag demo
 
 library
   hs-source-dirs:     src
-  exposed-modules:    Language.Javascript.JSaddle.Terminal
-                      Language.Javascript.JSaddle.Terminal.Protocol
+  exposed-modules:    Language.Javascript.JSaddle.Terminal.Protocol
                       Language.Javascript.JSaddle.Terminal.Bootstrap
   build-depends:      base >=4.16 && <5
                     , aeson
@@ -39,14 +38,16 @@ library
                     , jsaddle-warp >=0.9.4 && <0.10
                     , stm
                     , text
-                    , unix
                     , warp
                     , websockets
   ghc-options:        -Wall
   default-language:   Haskell2010
-  -- Raw-mode stdin/termios: POSIX only.
-  if os(windows)
-    buildable: False
+  -- The tunnel runner needs raw-mode stdin/termios: POSIX only.  The framing
+  -- (Protocol) and iframe JS (Bootstrap) are pure and build everywhere, so
+  -- IDE-side consumers (leksah) can link this library on Windows too.
+  if !os(windows)
+    exposed-modules:  Language.Javascript.JSaddle.Terminal
+    build-depends:    unix
 
 executable jsaddle-terminal-demo
   main-is:            Main.hs

--- a/jsaddle-webview2/cbits/WebView2Shim.c
+++ b/jsaddle-webview2/cbits/WebView2Shim.c
@@ -371,6 +371,13 @@ static LRESULT CALLBACK wndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp)
 
 /* ------------------------------------------- API called from Haskell */
 
+/* The Win32 HWND of the window hosting the WebView2, so the embedding
+   application can do native window integration (menu bar, dialogs). */
+void *wv2GetHwnd(JSaddleWV2 *app)
+{
+    return (void *)app->hwnd;
+}
+
 void wv2SetHandlers(JSaddleWV2 *app, HsStablePtr start, HsStablePtr result, HsStablePtr sync)
 {
     app->startHandler = start;

--- a/jsaddle-webview2/src/Language/Javascript/JSaddle/WebView2.hs
+++ b/jsaddle-webview2/src/Language/Javascript/JSaddle/WebView2.hs
@@ -20,6 +20,7 @@ module Language.Javascript.JSaddle.WebView2
     , run'
     , WebView2Config(..)
     , WebView2(..)
+    , webView2Hwnd
     ) where
 
 import Control.Monad (unless)
@@ -31,12 +32,21 @@ import Data.Text.Encoding (encodeUtf8)
 
 import Foreign.C.String (CString)
 import Foreign.C.Types (CInt(..))
+import Foreign.Ptr (Ptr)
 import Foreign.StablePtr (StablePtr, newStablePtr)
 
 import Language.Javascript.JSaddle (JSM)
 import Language.Javascript.JSaddle.WebView2.Internal
        (jsaddleMain, jsaddleMainHTML, jsaddleMainURL, WebView2(..))
 import System.Environment (getProgName)
+
+foreign import ccall wv2GetHwnd :: WebView2 -> IO (Ptr ())
+
+-- | The Win32 @HWND@ of the window hosting the WebView2, for native window
+--   integration (menu bar, dialogs) by the embedding application.  Only
+--   meaningful once the 'run'' callback has been entered.
+webView2Hwnd :: WebView2 -> IO (Ptr ())
+webView2Hwnd = wv2GetHwnd
 
 foreign import ccall runJsaddleWebView2
     :: StablePtr (WebView2 -> IO ())


### PR DESCRIPTION
## Summary

Three small changes needed to embed jsaddle in native front ends (a
GTK4/WebKitGTK 6.0 app on Linux and a WebView2 app on Windows). No behaviour
changes on existing platforms.

## jsaddle-terminal: build the library on Windows (pure modules only)

The whole package was `buildable: False` on Windows because the tunnel runner
(`Language.Javascript.JSaddle.Terminal`) needs raw-mode stdin/termios, which is
POSIX-only. But the framing (`.Terminal.Protocol`) and the iframe bootstrap JS
(`.Terminal.Bootstrap`) are pure and build everywhere.

IDE-side consumers only import those two modules, so the library now exposes
them unconditionally and gates just the runner module — plus its deps — behind
`if !os(windows)`. This lets an embedder link jsaddle-terminal on Windows.

The runner's deps (`aeson`, `jsaddle-warp`, `stm`, `text`, `unix`, `warp`,
`websockets`) move under the same guard. This also drops `jsaddle-warp` from
the Windows build, which matters because `jsaddle-warp` caps `aeson < 2.3` and
would otherwise constrain the whole plan.

## jsaddle-webview2: expose the host window's HWND

Adds `wv2GetHwnd` (C) / `webView2Hwnd :: WebView2 -> IO (Ptr ())` (Haskell) so
the embedding application can reach the Win32 `HWND` of the window hosting the
WebView2 and do native window integration — install a menu bar, run file
dialogs, etc. Only meaningful once the `run'` callback has been entered (the
HWND exists by then).

## Testing

- jsaddle-terminal library builds on the Windows cross (ucrt64) and unchanged
  on POSIX.
- jsaddle-webview2 builds; `webView2Hwnd` returns the shim's HWND at runtime.
- Both are consumed by leksah's new `leksah-webkitgtk` and `leksah-webview2`
  front ends (Linux native + Windows cross), which build via haskell.nix.
